### PR TITLE
Make docker commands workable on windows (DONT MERGE)

### DIFF
--- a/seed-my-ontology-repo.pl
+++ b/seed-my-ontology-repo.pl
@@ -110,12 +110,33 @@ else {
 my $TEMPLATEDIR = 'template';
 
 my @files;
-finddepth(sub {
-    return if($_ eq '.' || $_ eq '..');
-    push @files, $File::Find::name;
-},
-$TEMPLATEDIR
-);
+#finddepth(sub {
+#    return if($_ eq '.' || $_ eq '..');
+#    push @files, $File::Find::name;
+#},
+#$TEMPLATEDIR
+#);
+
+my @dirs = ($TEMPLATEDIR);
+
+while (@dirs) {
+	my $thisdir = shift @dirs;
+	opendir my $dh, $thisdir;
+	while (my $entry = readdir $dh) {
+		next if $entry eq '.';
+		next if $entry eq '..';
+
+		my $fullname = "$thisdir/$entry";
+		print "FOUND: $fullname \n";
+
+		if (-d $fullname) {
+			push @dirs, $fullname;
+		} else {
+			push @files, $fullname;
+		}
+	}
+}
+
 #push(@files, "$TEMPLATEDIR/.gitignore");
 
 while (my $f = shift @files) {
@@ -235,7 +256,6 @@ sub runcmd {
             runcmd("$pre$_$post", $exit_on_fail);
         }
         return;
-        
     }
     my $err = system($cmd);
     if ($err) {

--- a/seed-via-docker.bat
+++ b/seed-via-docker.bat
@@ -1,0 +1,2 @@
+::BATCH file to seed new ontology repo via docker
+docker run -v %cd%:/work -w /work --rm -ti obolibrary/oskfull ./seed-my-ontology-repo.pl -e obo-ci-reports-all@groups.io %*


### PR DESCRIPTION
I added a bat file for the seeding of a new repo and successfully generated a new ontology on windows (with only docker installed). 

However, there was one snippet in the seed script (perl) that was not compatible with the windows file system, I dont know why: listing all files in the template directory using finddepth() did not descent into subdirectories (listing only files in the top level dir). I changed the traversal method now. Locally I generated two repos, one with the old traversal, one with the new, and compared the log files plus diff of the resulting releases. I think they are identical. Before we merge: Is there any test we should run that makes sure the new directory listing is exactly the same as the old? 