### PR TITLE
Do not use run.sh docker wrapper as travis already runs in a container

### DIFF
--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - docker pull obolibrary/osklite
 
 # command to run tests
-script: cd src/ontology && ./run.sh make test
+script: cd src/ontology && make test
 
 #after_success:
 #  coveralls

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 before_install:
-  - docker pull obolibrary/osklite
+  - docker pull obolibrary/odkfull
 
 # command to run tests
 script: cd src/ontology && make test


### PR DESCRIPTION
See #93

Currently we run docker-in-docker which is not necessarily bad but a bit odd/inceptiony and not necessary. The travis.yml already configures the travis job to run in an odk container.