### PR TITLE
Change ontology-starter-kit references to ontology-development-kit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# This makefile is purely for running tests on the complete ontology-starter-kit package on travis;
+# This makefile is purely for running tests on the complete ontology-development-kit package on travis;
 # users should not need to use this
 
 # command used in make test.

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ It is possible to do this without docker, see below for instructions
 
 # Generating an ontology project
 
-## 1. Download this starter package
+## 1. Download the ontology development kit
 
-It's recommended you get a release version: https://github.com/INCATools/ontology-starter-kit/releases
+It's recommended you get a release version: https://github.com/INCATools/ontology-development-kit/releases
 
 ## Initialize
 
-First you must be in the root level of the starter kit
+First you must be in the root level of the kit
 
     cd ontology-development-kit
 
@@ -59,7 +59,7 @@ You can customize at this stage, or (recommended) after making an initial push t
 
 ## Push to GitHub
 
-The starter kit will automatically initialize a git project, add all files and commit.
+The development kit will automatically initialize a git project, add all files and commit.
 
 You will need to create a project on GitHub.
 
@@ -118,7 +118,7 @@ See the README-editors.md file that has been generated for your project.
 
 ## Troubleshooting.
 
-If you have issues, file them here: https://github.com/INCATools/ontology-starter-kit/issues
+If you have issues, file them here: https://github.com/INCATools/ontology-development-kit/issues
 
 Some things to check:
 
@@ -141,7 +141,7 @@ info.
 
 The ODK is designed for creating a new repo for a new ontology. It can still be used to help figure out how to migrate an existing github repository to the ODK structure. There are different ways to do this.
 
- * Manually compare your ontology against the [template](https://github.com/INCATools/ontology-starter-kit/tree/master/template) folder and make necessary adjustments
+ * Manually compare your ontology against the [template](https://github.com/INCATools/ontology-development-kit/tree/master/template) folder and make necessary adjustments
  * Run the seed script as if creating a new repo. Manually compare this with your existing repo and use `git mv` to rearrange, and adding any missing files by copying them across and doing a `git add`
  * Create a new repo de novo and abandon your existing one, using github issue mover to move tickets across.
  

--- a/seed-my-ontology-repo.pl
+++ b/seed-my-ontology-repo.pl
@@ -227,7 +227,7 @@ chdir($targetdir);
 
 runcmd("git init");
 runcmd("git add -A .");
-runcmd("git commit -m 'initial commit of ontology sources of $ontid using ontology-starter-kit' -a") unless $no_commit;
+runcmd("git commit -m 'initial commit of ontology sources of $ontid using ontology-development-kit' -a") unless $no_commit;
 
 if ($n_errors) {
     print STDERR "WARNING: encountered errors - the commands below may not work\n";
@@ -249,7 +249,7 @@ if ($prep_initial_release) {
     runcmd("git add $ontid.{obo,owl}");
     runcmd("git add imports/*.{obo,owl}") if @depends;
     runcmd("git add subsets/*.{obo,owl}") if -d "src/ontology/subsets";
-    runcmd("git commit -m 'initial release of $ontid using ontology-starter-kit' -a") unless $no_commit;
+    runcmd("git commit -m 'initial release of $ontid using ontology-development-kit' -a") unless $no_commit;
 }
 
 runcmd("git status");
@@ -312,7 +312,7 @@ sub runcmd {
 
     # not all shells support {...} syntax
     # we auto-unfold these here
-    # see https://github.com/INCATools/ontology-starter-kit/pull/49
+    # see https://github.com/INCATools/ontology-development-kit/pull/49
     if ($cmd =~ m@(.*)\{(.*)\}(.*)@) {
         my ($pre, $matchlist, $post) = ($1,$2,$3);
         my @expansions = split(/,/, $matchlist);
@@ -401,7 +401,7 @@ sub usage {
 
     $sn  -d po -d ro -d pato -u obophenotype -t "Triffid Behavior ontology" triffo
 
-    See http://github.com/cmungall/ontology-starter-kit for details
+    See http://github.com/cmungall/ontology-development-kit for details
 
     Options:
 

--- a/template/.travis.yml
+++ b/template/.travis.yml
@@ -21,7 +21,7 @@ branches:
     - test-travis
 
 ### Add your own lists here
-### See https://github.com/INCATools/ontology-starter-kit/issues/35
+### See https://github.com/INCATools/ontology-development-kit/issues/35
 notifications:
   email:
     - obo-ci-reports-all@groups.io

--- a/template/README.md
+++ b/template/README.md
@@ -25,4 +25,4 @@ Please use this GitHub repository's [Issue tracker](https://github.com/MY-GITHUB
 
 ## Acknowledgements
 
-This ontology repository was created using the [ontology starter kit](https://github.com/INCATools/ontology-starter-kit)
+This ontology repository was created using the [ontology development kit](https://github.com/INCATools/ontology-development-kit).

--- a/template/src/ontology/Makefile
+++ b/template/src/ontology/Makefile
@@ -1,6 +1,6 @@
 # ----------------------------------------
 # Makefile for foobar
-# Generated using ontology-starter-kit
+# Generated using ontology-development-kit
 # ----------------------------------------
 # <do not edit above this line>
 


### PR DESCRIPTION
A very minor PR.  I noticed some stray references to the the old project name in comments and READMEs and such.  They were bugging me.