### PR TITLE
Critical: Fixing various issues with the initial import seeds and the pattern creation

### DIFF
--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -162,28 +162,32 @@ Datatype: rdf:PlainLiteral
 
 #}
 ^^^ src/ontology/imports/{{ imp.id }}_terms.txt
-{{ imp.id|upper }}:0000001
-{{ imp.id|upper }}:0000002
-{{ imp.id|upper }}:0000003
-{% if imp.id == 'ro' %}
+{%- if imp.id == 'ro' %}
 BFO:0000050
 RO:0002202
-{% endif %}
-{% if imp.id == 'bfo' %}
+{%- elif imp.id == 'bfo' %}
 BFO:0000040
-{% endif %}
-{% if imp.id == 'go' %}
+{%- elif imp.id == 'go' %}
 GO:0008150
-{% endif %}
-{% if imp.id == 'uberon' %}
-UBERON:0002048
-{% endif %}
-{% if imp.id == 'cl' %}
-UBERON:0002048
-{% endif %}
-{% if imp.id == 'pato' %}
-PATO:0000052
-{% endif %}
+{%- elif imp.id == 'uberon' %}
+UBERON:0001062
+{%- elif imp.id == 'cl' %}
+CL:0000000
+{%- elif imp.id == 'pato' %}
+PATO:0000001
+{%- elif imp.id == 'mpath' %}
+MPATH:0
+{%- elif imp.id == 'chebi' %}
+CHEBI:24431
+{%- elif imp.id == 'hsapdv' %}
+http://purl.obolibrary.org/obo/HsapDv_0000000
+{%- elif imp.id == 'nbo' %}
+NBO:0000313
+{%- else %}
+{{ imp.id|upper }}:0000000
+{{ imp.id|upper }}:0000001
+{{ imp.id|upper }}:0000002
+{%- endif %}
 {% endfor %}
 {#-
 

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -338,11 +338,11 @@ patterns: $(PATTERN_IMPORTS)
 pattern_files := $(wildcard $(PATTERNDIR)/*.yaml)
 pattern_tsv_files := $(wildcard $(PATTERNDIR)/*.tsv)
 
-$(PATTERNDIR)/%.owl: $(PATTERNDIR)/%.yaml $(PATTERNDIR)/%.tsv $(SRC)
+$(PATTERNDIR)/%.ofn: $(PATTERNDIR)/%.yaml $(PATTERNDIR)/%.tsv $(SRC)
 	dosdp-tools generate --catalog=catalog-v001.xml --infile=$(word 2, $^) --template=$< --ontology=$(word 3, $^) --obo-prefixes=true  --outfile=$@
 
 
-pattern_modules := $(patsubst %.yaml, $(IMS)/patterns/%.ofn, $(notdir $(wildcard $(PATTERNDIR)/*.yaml)))
+pattern_modules := $(patsubst %.yaml, $(PATTERNDIR)/%.ofn, $(notdir $(wildcard $(PATTERNDIR)/*.yaml)))
 
 $(PATTERNDIR)/definitions.owl: $(pattern_modules)
 	$(ROBOT) merge $(addprefix -i , $(pattern_modules)) annotate --ontology-iri $(ONTBASE)/patterns/defintions.owl -o $@


### PR DESCRIPTION
This PR contains two fixes:

1) obvious one to the pattern generation system (a wrong path in one of the goals)
2) A few issues with the default import system. I still dont like it: I would prefer ROBOT to [allow empty seeds](https://github.com/ontodev/robot/issues/434), resulting in empty ontologies being extracted. This is algorithmically well-defined behavior, and precludes the need of hacking some kind of default seed for the initial repo seeding process.