### PR TITLE
Add no-cache to docker build. Ensure tools are downloaded each time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ VERSION = "v1.2.5"
 IM=obolibrary/odkfull
 
 docker-build:
-	@docker build -t $(IM):$(VERSION) . \
+	@docker build --no-cache -t $(IM):$(VERSION) . \
 	&& docker tag $(IM):$(VERSION) $(IM):latest
 
 docker-run:


### PR DESCRIPTION
@matentzn @cmungall I needed this to ensure that the new owltools was downloaded. Otherwise it was using a cache from a previous download. Should we do this every time?