### PR TITLE
Ontology Metadata Annotations added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ schema/project-schema.json:
 	./odk/odk.py dump-schema > $@
 
 # Building docker image
-VERSION = "v1.2.8" 
+VERSION = "v1.2.9" 
 IM=obolibrary/odkfull
 
 docker-build:

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -320,6 +320,12 @@ class OntologyProject(JsonSchemaMixin):
     primary_release : str = 'full'
     """Which release file should be published as the primary release artefact, i.e. foo.owl"""
     
+    license : str = 'Unspecified'
+    """Which license is ontology supplied under; ideally CC-BY."""
+    
+    description : str = 'None'
+    """Provide a short description of the ontology"""
+    
     use_dosdps : bool = False
     """if true use dead simple owl design patterns"""
     

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -2,9 +2,12 @@
 *.tmp
 src/ontology/mirror
 src/ontology/mirror/*
-src/ontology/{{ project.id }}.obo
-src/ontology/{{ project.id }}.owl
-src/ontology/{{ project.id }}-base.owl
+src/ontology/{{ project.id }}.*
+src/ontology/{{ project.id }}-base.*
+src/ontology/{{ project.id }}-basic.*
+src/ontology/{{ project.id }}-full.*
+src/ontology/{{ project.id }}-simple.*
+src/ontology/{{ project.id }}-simple-non-classified.*
 semantic.cache
 bin/
 src/ontology/seed.txt

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -2,7 +2,9 @@
 *.tmp
 src/ontology/mirror
 src/ontology/mirror/*
-src/ontology/{{ project.id }}.*
+src/ontology/{{ project.id }}.owl
+src/ontology/{{ project.id }}.obo
+src/ontology/{{ project.id }}.json
 src/ontology/{{ project.id }}-base.*
 src/ontology/{{ project.id }}-basic.*
 src/ontology/{{ project.id }}-full.*

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -45,6 +45,8 @@ Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
 Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
 Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
 Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+Prefix(dce:=<http://purl.org/dc/elements/1.1/>)
+Prefix(dcterms:=<http://purl.org/dc/terms/>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/{{ project.id }}.owl>
@@ -61,7 +63,9 @@ Import(<http://purl.obolibrary.org/obo/{{ project.id }}/patterns/pattern.owl>)
 {% endif -%}
 {% endif %}
 
-Annotation(rdfs:comment "{{ project.title }}")
+Annotation(dce:title "{{ project.title }}")
+Annotation(dcterms:license "{{ project.license }}")
+Annotation(dce:description "{{ project.description }}")
 
 Declaration(Class(<http://purl.obolibrary.org/obo/{{ project.id | upper }}_00000000>))
 


### PR DESCRIPTION
ROBOT QC requires dcterms:license, dce:title and dc:description to be present, so added that in and made it possible to config. Please not that I do not assume a  license as default value here.