### PR TITLE
Add `fastobo-validator` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ RUN wget https://github.com/ontodev/robot/releases/download/$ROBOT/robot.jar -O 
     
 ENV PATH "/tools/:$PATH"
 
+# Setup fastobo-validator
+RUN wget https://dl.bintray.com/fastobo/fastobo-validator/stable/fastobo_validator-x86_64-linux-musl.tar.gz -O- | tar xzC /tools
+
 # Setup dosdp tools
 ENV V=0.13.1
 RUN wget -nv https://github.com/INCATools/dosdp-tools/releases/download/v$V/dosdp-tools-$V.tgz && tar -zxvf dosdp-tools-$V.tgz && mv dosdp-tools-$V /tools/dosdp-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ WORKDIR /tools
 COPY requirements.txt /tools/
 
 # The following row are required to build and install numpy, which is a prerequisite for pandas
-RUN apk add --no-cache make automake gcc g++ subversion python3-dev
-RUN pip3 install -r requirements.txt && pip3 install jsonschema ruamel.yaml requests jsonpath_rw numpy
-RUN pip3 install pandas
+RUN apk add -t pandas-deps --no-cache make automake gcc g++ subversion python3-dev \
+ && pip3 install -r requirements.txt \
+ && pip3 install jsonschema ruamel.yaml requests jsonpath_rw numpy \
+ && pip3 install pandas \
+ && apk del pandas-deps
 
 ### 2. Get Java via the package manager
 


### PR DESCRIPTION
I added the latest stable `fastobo-validator` to the Dockerfile as discussed in #214 . Usage is as follow:
```make
x.obo: x.owl
  $(ROBOT) convert --check false -i $< -f obo -o $@.tmp.obo \ 
  && fastobo-validator $@.tmp.obo \
  && mv $@.tmp.obo $@; 
```