### PR TITLE
Issue 232 external date

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -6,7 +6,7 @@ See https://github.com/ontodev/robot/issues/37
 
 For help on command line usage:
 
-odk.py
+odk.py 
 
 """
 from typing import Optional, Set, List, Union, Dict, Any
@@ -50,20 +50,20 @@ class Product(JsonSchemaMixin):
 
     Here, a product is something that is produced by an ontology workflow.
     A product can be manifested in different formats.
-
+    
     For example, goslim_prok is a subset (aka slim) product from GO,
     this can be manifest as obo, owl, json
     """
-
+    
     id : str
     """ontology project identifier / shorthand; e.g. go, obi, envo"""
-
+    
     description: Optional[str] = None
     """A concise textual description of the product"""
-
+    
     rebuild_if_source_changes : bool = True
     """If false then previously downloaded versions of external ontologies are used"""
-
+    
     robot_settings : Optional[CommandSettings] = None
     """Amount of memory to provide for robot. Working with large products such as CHEBI imports may require additional memory"""
 
@@ -74,7 +74,7 @@ class SubsetProduct(Product):
     Represents an individual subset.
     Examples: goslim_prok (in go), eco_subset (in ro)
     """
-
+    
     creators : Optional[List[Person]] = None
     """list of people that are credited as creators/maintainers of the subset"""
 
@@ -86,7 +86,7 @@ class ImportProduct(Product):
     Examples: 'uberon' (in go)
     Imports are typically built from an upstream source, but this can be configured
     """
-
+    
     mirror_from: Optional[Url] = None
     """if specified this URL is used rather than the default OBO PURL for the main OWL product"""
 
@@ -104,7 +104,7 @@ class PatternPipelineProduct(Product):
 @dataclass
 class PatternProduct(Product):
     """Represents a DOSDP template product
-
+    
     The products here can be manfested as CSVs (from 'parse'ing OWL)
     or they may be OWL (from the dosdp 'generate' command)
     """
@@ -125,20 +125,20 @@ class ExportProduct(Product):
     """
     Represents a export product, such as one produced by a SPARQL query
     """
-
+    
     method : str = "sparql"
     """How the export is generated. Currently only SPARQL is supported"""
-
+    
     output_format : str = "tsv"
     """Output format, see robot query for details."""
-
+    
     is_validation_check : bool = False
     """If true, then the presence of one or more results in query results in pipeline fail. Note these are in addition to the main robot report command"""
 
     export_specification: Optional[str] = None
     """Specification such as a SPARQL query. If unset, assumes a default path of ../sparql/{{id}}.sparql"""
-
-
+    
+    
 @dataclass_json
 @dataclass
 class ProductGroup(JsonSchemaMixin):
@@ -163,13 +163,13 @@ class ProductGroup(JsonSchemaMixin):
     that don't do anything fancy, but at the price of overall
     complexity
     """
-
+    
     ids : Optional[List[OntologyHandle]] = None
     """potentially deprecated, specify explicit product list instead"""
-
+    
     disabled : bool = False
     """if set then this is not used"""
-
+    
     rebuild_if_source_changes : bool = True
     """if false then upstream ontology is re-downloaded any time edit file changes"""
 
@@ -188,13 +188,13 @@ class SubsetGroup(ProductGroup):
 
     Controls export of subsets/slims into the "subsets/" directory
     """
-
+    
     products : Optional[List[SubsetProduct]] = None
     """all subset products"""
-
+    
     directory : Directory = "subsets/"
     """directory where subsets are placed after extraction from ontology"""
-
+    
     def _add_stub(self, id : OntologyHandle):
         if self.products is None:
             self.products = []
@@ -208,7 +208,7 @@ class ImportGroup(ProductGroup):
 
     Controls extraction of import modules via robot extract into the "imports/" directory
     """
-
+    
     products : Optional[List[ImportProduct]] = None
     """all import products"""
 
@@ -228,7 +228,7 @@ class PatternPipelineGroup(ProductGroup):
 
     Controls the handling of patterns data in the "src/patterns/data" directory
     """
-
+    
     products : Optional[List[PatternPipelineProduct]] = None
     """all pipeline products"""
 
@@ -236,7 +236,7 @@ class PatternPipelineGroup(ProductGroup):
         if self.products is None:
             self.products = []
         self.products.append(PatternPipelineProduct(id=id))
-
+            
 @dataclass_json
 @dataclass
 class PatternGroup(ProductGroup):
@@ -244,23 +244,23 @@ class PatternGroup(ProductGroup):
     A configuration section that consists of a list of `PatternProduct` descriptions
 
     """
-
+    
     products : Optional[List[PatternProduct]] = None
     """all DOSDP pattern products"""
 
     directory : Directory = "../patterns/"
     """directory where pattern source lives, also where TSV exported to"""
 
-
+    
 @dataclass_json
 @dataclass
 class RoboTemplateGroup():
     """
     A configuration section that consists of a list of `RoboTemplateProduct` descriptions
     """
-
+    
     directory : Directory = "../templates/"
-
+    
     products : Optional[List[RoboTemplateProduct]] = None
 
 @dataclass_json
@@ -271,14 +271,14 @@ class ExportGroup(ProductGroup):
 
     Controls generation of exports (typically SPARQL via robot query) into the "reports/" directory
     """
-
+    
     products : Optional[List[ExportProduct]] = None
     """all export products"""
 
     directory : Directory = "reports/"
     """directory where exports are placed"""
 
-
+    
 @dataclass_json
 @dataclass
 class OntologyProject(JsonSchemaMixin):
@@ -298,76 +298,76 @@ class OntologyProject(JsonSchemaMixin):
 
     repo : str = ""
     """Name of repo (do not include org). E.g. cell-ontology"""
-
+    
     github_org : str = ""
     """Name of github org or username where repo will live. Examples: obophenotype, cmungall"""
 
     edit_format : str = 'owl'
     """Format in which the edit file is managed, either obo or owl"""
-
+    
     robot_version: Optional[str] = None
     """Only set this if you want to pin to a specific robot version"""
-
+    
     robot_settings: Optional[CommandSettings] = None
     """Settings to pass to ROBOT such as amount of memory to be used"""
-
+    
     robot_java_args: Optional[str] = ""
     """Java args to pass to ROBOT at runtime, such as -Xmx6G"""
 
     use_external_date: bool = False
     """Flag to set if you want odk to use the host `date` rather than the docker internal `date`"""
-
+    
     reasoner : str = 'ELK'
     """Name of reasoner to use in ontology pipeline, see robot reason docs for allowed values"""
-
+    
     primary_release : str = 'full'
     """Which release file should be published as the primary release artefact, i.e. foo.owl"""
-
+    
     license : str = 'Unspecified'
     """Which license is ontology supplied under; ideally CC-BY."""
-
+    
     description : str = 'None'
     """Provide a short description of the ontology"""
-
+    
     use_dosdps : bool = False
     """if true use dead simple owl design patterns"""
-
+    
     import_pattern_ontology : bool = False
     """if true import pattern.owl"""
-
+    
     gzip_main : bool = False
     """if true add a gzipped version of the main artefact"""
-
+    
     release_artefacts : List[str] = field(default_factory=lambda: ['full', 'base'])
     """A list of release artefacts you wish to be exported."""
-
+    
     export_formats : List[str] = field(default_factory=lambda: ['owl', 'obo'])
     """A list of export formats you wish your release artefacts to be exported to, such as owl, obo, gz, ttl."""
-
+    
     namespaces : Optional[List[str]] = None
     """A list of namespaces that are considered at home in this ontology. Used for certain filter commands."""
 
     dosdp_tools_options: str = "--obo-prefixes=true"
     """default parameters for dosdp-tools"""
-
+    
     report_fail_on : Optional[str] = None
     """see robot report docs for details. """
-
+    
     travis_emails : Optional[List[Email]] = None ## ['obo-ci-reports-all@groups.io']
     """Emails to use in travis configurations. """
-
+    
     obo_format_options : str = ""
     """Additional args to pass to robot when saving to obo. TODO consider changing to a boolean for checks"""
-
+    
     uribase : str = 'http://purl.obolibrary.org/obo'
     """Base URI for PURLs. DO NOT MODIFY AT THIS TIME, code is still hardwired for OBO """
-
+    
     contact : Optional[Person] = None
     """Single contact for ontology as required by OBO"""
-
+    
     creators : Optional[List[Person]] = None
     """List of ontology creators (currently setting this has no effect)"""
-
+    
     contributors : Optional[List[Person]] = None
     """List of ontology contributors (currently setting this has no effect)"""
 
@@ -380,7 +380,7 @@ class OntologyProject(JsonSchemaMixin):
 
     pattern_group : Optional[PatternGroup] = None
     """Block that includes information on all DOSDP templates used"""
-
+    
     pattern_pipelines_group : Optional[PatternPipelineGroup] = None
     """Block that includes information on all ontology imports to be generated"""
 
@@ -410,7 +410,7 @@ class ExecutionContext(JsonSchemaMixin):
     project : Optional[OntologyProject] = None
     meta : str = ""
 
-
+    
 @dataclass
 class Generator(object):
     """
@@ -472,7 +472,7 @@ def save_project_yaml(project : OntologyProject, path : str):
     json_obj = json.loads(json_str)
     with open(path, "w") as f:
         f.write(yaml.dump(json_obj, default_flow_style=False))
-
+        
 def unpack_files(basedir, txt):
     """
     This unpacks a custom tar-like format in which multiple file paths
@@ -541,7 +541,7 @@ def create_dynfile(config, templatedir, input, output):
     mg = Generator()
     mg.load_config(config)
     print(mg.generate('{}/_dynamic_files.jinja2'.format(templatedir)))
-
+    
 @cli.command()
 @click.option('-C', '--config', type=click.File('r'))
 @click.option('-o', '--output', required=True)
@@ -553,7 +553,7 @@ def export_project(config, output):
     mg.load_config(config)
     project = mg.context.project
     save_project_yaml(project, output)
-
+    
 @cli.command()
 def dump_schema():
     """
@@ -676,9 +676,9 @@ def runcmd(cmd):
         logging.error(err)
     if p.returncode != 0:
         raise Exception('Failed: {}'.format(cmd))
+    
 
-
-
-
+            
+                
 if __name__ == "__main__":
     cli()

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -6,7 +6,7 @@ See https://github.com/ontodev/robot/issues/37
 
 For help on command line usage:
 
-odk.py 
+odk.py
 
 """
 from typing import Optional, Set, List, Union, Dict, Any
@@ -50,20 +50,20 @@ class Product(JsonSchemaMixin):
 
     Here, a product is something that is produced by an ontology workflow.
     A product can be manifested in different formats.
-    
+
     For example, goslim_prok is a subset (aka slim) product from GO,
     this can be manifest as obo, owl, json
     """
-    
+
     id : str
     """ontology project identifier / shorthand; e.g. go, obi, envo"""
-    
+
     description: Optional[str] = None
     """A concise textual description of the product"""
-    
+
     rebuild_if_source_changes : bool = True
     """If false then previously downloaded versions of external ontologies are used"""
-    
+
     robot_settings : Optional[CommandSettings] = None
     """Amount of memory to provide for robot. Working with large products such as CHEBI imports may require additional memory"""
 
@@ -74,7 +74,7 @@ class SubsetProduct(Product):
     Represents an individual subset.
     Examples: goslim_prok (in go), eco_subset (in ro)
     """
-    
+
     creators : Optional[List[Person]] = None
     """list of people that are credited as creators/maintainers of the subset"""
 
@@ -86,7 +86,7 @@ class ImportProduct(Product):
     Examples: 'uberon' (in go)
     Imports are typically built from an upstream source, but this can be configured
     """
-    
+
     mirror_from: Optional[Url] = None
     """if specified this URL is used rather than the default OBO PURL for the main OWL product"""
 
@@ -104,7 +104,7 @@ class PatternPipelineProduct(Product):
 @dataclass
 class PatternProduct(Product):
     """Represents a DOSDP template product
-    
+
     The products here can be manfested as CSVs (from 'parse'ing OWL)
     or they may be OWL (from the dosdp 'generate' command)
     """
@@ -125,20 +125,20 @@ class ExportProduct(Product):
     """
     Represents a export product, such as one produced by a SPARQL query
     """
-    
+
     method : str = "sparql"
     """How the export is generated. Currently only SPARQL is supported"""
-    
+
     output_format : str = "tsv"
     """Output format, see robot query for details."""
-    
+
     is_validation_check : bool = False
     """If true, then the presence of one or more results in query results in pipeline fail. Note these are in addition to the main robot report command"""
 
     export_specification: Optional[str] = None
     """Specification such as a SPARQL query. If unset, assumes a default path of ../sparql/{{id}}.sparql"""
-    
-    
+
+
 @dataclass_json
 @dataclass
 class ProductGroup(JsonSchemaMixin):
@@ -163,13 +163,13 @@ class ProductGroup(JsonSchemaMixin):
     that don't do anything fancy, but at the price of overall
     complexity
     """
-    
+
     ids : Optional[List[OntologyHandle]] = None
     """potentially deprecated, specify explicit product list instead"""
-    
+
     disabled : bool = False
     """if set then this is not used"""
-    
+
     rebuild_if_source_changes : bool = True
     """if false then upstream ontology is re-downloaded any time edit file changes"""
 
@@ -188,13 +188,13 @@ class SubsetGroup(ProductGroup):
 
     Controls export of subsets/slims into the "subsets/" directory
     """
-    
+
     products : Optional[List[SubsetProduct]] = None
     """all subset products"""
-    
+
     directory : Directory = "subsets/"
     """directory where subsets are placed after extraction from ontology"""
-    
+
     def _add_stub(self, id : OntologyHandle):
         if self.products is None:
             self.products = []
@@ -208,7 +208,7 @@ class ImportGroup(ProductGroup):
 
     Controls extraction of import modules via robot extract into the "imports/" directory
     """
-    
+
     products : Optional[List[ImportProduct]] = None
     """all import products"""
 
@@ -228,7 +228,7 @@ class PatternPipelineGroup(ProductGroup):
 
     Controls the handling of patterns data in the "src/patterns/data" directory
     """
-    
+
     products : Optional[List[PatternPipelineProduct]] = None
     """all pipeline products"""
 
@@ -236,7 +236,7 @@ class PatternPipelineGroup(ProductGroup):
         if self.products is None:
             self.products = []
         self.products.append(PatternPipelineProduct(id=id))
-            
+
 @dataclass_json
 @dataclass
 class PatternGroup(ProductGroup):
@@ -244,23 +244,23 @@ class PatternGroup(ProductGroup):
     A configuration section that consists of a list of `PatternProduct` descriptions
 
     """
-    
+
     products : Optional[List[PatternProduct]] = None
     """all DOSDP pattern products"""
 
     directory : Directory = "../patterns/"
     """directory where pattern source lives, also where TSV exported to"""
 
-    
+
 @dataclass_json
 @dataclass
 class RoboTemplateGroup():
     """
     A configuration section that consists of a list of `RoboTemplateProduct` descriptions
     """
-    
+
     directory : Directory = "../templates/"
-    
+
     products : Optional[List[RoboTemplateProduct]] = None
 
 @dataclass_json
@@ -271,14 +271,14 @@ class ExportGroup(ProductGroup):
 
     Controls generation of exports (typically SPARQL via robot query) into the "reports/" directory
     """
-    
+
     products : Optional[List[ExportProduct]] = None
     """all export products"""
 
     directory : Directory = "reports/"
     """directory where exports are placed"""
 
-    
+
 @dataclass_json
 @dataclass
 class OntologyProject(JsonSchemaMixin):
@@ -298,73 +298,76 @@ class OntologyProject(JsonSchemaMixin):
 
     repo : str = ""
     """Name of repo (do not include org). E.g. cell-ontology"""
-    
+
     github_org : str = ""
     """Name of github org or username where repo will live. Examples: obophenotype, cmungall"""
 
     edit_format : str = 'owl'
     """Format in which the edit file is managed, either obo or owl"""
-    
+
     robot_version: Optional[str] = None
     """Only set this if you want to pin to a specific robot version"""
-    
+
     robot_settings: Optional[CommandSettings] = None
     """Settings to pass to ROBOT such as amount of memory to be used"""
-    
+
     robot_java_args: Optional[str] = ""
     """Java args to pass to ROBOT at runtime, such as -Xmx6G"""
-    
+
+    use_external_date: bool = False
+    """Flag to set if you want odk to use the host `date` rather than the docker internal `date`"""
+
     reasoner : str = 'ELK'
     """Name of reasoner to use in ontology pipeline, see robot reason docs for allowed values"""
-    
+
     primary_release : str = 'full'
     """Which release file should be published as the primary release artefact, i.e. foo.owl"""
-    
+
     license : str = 'Unspecified'
     """Which license is ontology supplied under; ideally CC-BY."""
-    
+
     description : str = 'None'
     """Provide a short description of the ontology"""
-    
+
     use_dosdps : bool = False
     """if true use dead simple owl design patterns"""
-    
+
     import_pattern_ontology : bool = False
     """if true import pattern.owl"""
-    
+
     gzip_main : bool = False
     """if true add a gzipped version of the main artefact"""
-    
+
     release_artefacts : List[str] = field(default_factory=lambda: ['full', 'base'])
     """A list of release artefacts you wish to be exported."""
-    
+
     export_formats : List[str] = field(default_factory=lambda: ['owl', 'obo'])
     """A list of export formats you wish your release artefacts to be exported to, such as owl, obo, gz, ttl."""
-    
+
     namespaces : Optional[List[str]] = None
     """A list of namespaces that are considered at home in this ontology. Used for certain filter commands."""
 
     dosdp_tools_options: str = "--obo-prefixes=true"
     """default parameters for dosdp-tools"""
-    
+
     report_fail_on : Optional[str] = None
     """see robot report docs for details. """
-    
+
     travis_emails : Optional[List[Email]] = None ## ['obo-ci-reports-all@groups.io']
     """Emails to use in travis configurations. """
-    
+
     obo_format_options : str = ""
     """Additional args to pass to robot when saving to obo. TODO consider changing to a boolean for checks"""
-    
+
     uribase : str = 'http://purl.obolibrary.org/obo'
     """Base URI for PURLs. DO NOT MODIFY AT THIS TIME, code is still hardwired for OBO """
-    
+
     contact : Optional[Person] = None
     """Single contact for ontology as required by OBO"""
-    
+
     creators : Optional[List[Person]] = None
     """List of ontology creators (currently setting this has no effect)"""
-    
+
     contributors : Optional[List[Person]] = None
     """List of ontology contributors (currently setting this has no effect)"""
 
@@ -377,7 +380,7 @@ class OntologyProject(JsonSchemaMixin):
 
     pattern_group : Optional[PatternGroup] = None
     """Block that includes information on all DOSDP templates used"""
-    
+
     pattern_pipelines_group : Optional[PatternPipelineGroup] = None
     """Block that includes information on all ontology imports to be generated"""
 
@@ -407,7 +410,7 @@ class ExecutionContext(JsonSchemaMixin):
     project : Optional[OntologyProject] = None
     meta : str = ""
 
-    
+
 @dataclass
 class Generator(object):
     """
@@ -469,7 +472,7 @@ def save_project_yaml(project : OntologyProject, path : str):
     json_obj = json.loads(json_str)
     with open(path, "w") as f:
         f.write(yaml.dump(json_obj, default_flow_style=False))
-        
+
 def unpack_files(basedir, txt):
     """
     This unpacks a custom tar-like format in which multiple file paths
@@ -538,7 +541,7 @@ def create_dynfile(config, templatedir, input, output):
     mg = Generator()
     mg.load_config(config)
     print(mg.generate('{}/_dynamic_files.jinja2'.format(templatedir)))
-    
+
 @cli.command()
 @click.option('-C', '--config', type=click.File('r'))
 @click.option('-o', '--output', required=True)
@@ -550,7 +553,7 @@ def export_project(config, output):
     mg.load_config(config)
     project = mg.context.project
     save_project_yaml(project, output)
-    
+
 @cli.command()
 def dump_schema():
     """
@@ -673,11 +676,9 @@ def runcmd(cmd):
         logging.error(err)
     if p.returncode != 0:
         raise Exception('Failed: {}'.format(cmd))
-    
 
-            
-                
+
+
+
 if __name__ == "__main__":
     cli()
-
-

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -34,7 +34,7 @@ OBO_FORMAT_OPTIONS =        {{ project.obo_format_options }}
 SPARQL_VALIDATION_CHECKS =  equivalent-classes trailing-whitespace owldef-self-reference xref-syntax nolabels
 SPARQL_EXPORTS =            basic-report class-count-by-prefix edges xrefs obsoletes synonyms
 
-TODAY   := $(shell date +%Y-%m-%d)
+TODAY   ?= $(shell date +%Y-%m-%d)
 
 {%- if project.use_dosdps %}
 DOSDP_SCHEMA=                http:// # change to PURL when ready.
@@ -47,7 +47,7 @@ PATTERN_RELEASE_FILES=       $(PATTERNDIR)/definitions.owl $(PATTERNDIR)/pattern
 FORMATS = $(sort {% for format in project.export_formats %} {{ format }}{% endfor %} owl)
 FORMATS_INCL_TSV = $(sort $(FORMAT) tsv)
 RELEASE_ARTEFACTS = $(sort {% for release in project.release_artefacts %} {{ release }}{% endfor %} base full)
- 
+
 # ----------------------------------------
 # Top-level targets
 # ----------------------------------------
@@ -74,14 +74,14 @@ all_main: $(MAIN_FILES)
 {% if project.import_group is defined %}
 IMPORTS = {% for imp in project.import_group.products %} {{ imp.id }}{% endfor %}
 {% else %}
-IMPORTS = 
+IMPORTS =
 {% endif %}
 IMPORT_ROOTS = $(patsubst %, imports/%_import, $(IMPORTS))
 IMPORT_FILES = $(foreach n,$(IMPORT_ROOTS), $(foreach f,$(FORMATS), $(n).$(f)))
 IMPORT_OWL_FILES = $(foreach n,$(IMPORT_ROOTS), $(n).owl)
 
 all_imports: $(IMPORT_FILES)
-{% for format in project.export_formats %} 
+{% for format in project.export_formats %}
 all_imports_{{ format }}: $(foreach n,$(IMPORT_ROOTS), $(n).{{ format }})
 {% endfor %}
 
@@ -93,7 +93,7 @@ all_imports_{{ format }}: $(foreach n,$(IMPORT_ROOTS), $(n).{{ format }})
 {% if project.subset_group is defined %}
 SUBSETS = {% for x in project.subset_group.products %} {{ x.id }}{% endfor %}
 {% else %}
-SUBSETS = 
+SUBSETS =
 {% endif %}
 SUBSET_ROOTS = $(patsubst %, subsets/%, $(SUBSETS))
 SUBSET_FILES = $(foreach n,$(SUBSET_ROOTS), $(foreach f,$(FORMATS_INCL_TSV), $(n).$(f)))
@@ -106,7 +106,7 @@ all_subsets: $(SUBSET_FILES)
 {% if project.pattern_group is defined %}
 PATTERNS = {% for x in project.pattern_group.products %} {{ x.id }}{% endfor %}
 {% else %}
-PATTERNS = 
+PATTERNS =
 {% endif %}
 PATTERN_ROOTS = $(patsubst %, $(PATTERNDIR)/%, $(PATTERNS))
 PATTERN_FILES = $(foreach n,$(PATTERN_ROOTS), $(n).owl)
@@ -162,7 +162,7 @@ prepare_initial_release: prepare_release
 # ----------------------------------------
 
 
-{% for release in project.release_artefacts -%} 
+{% for release in project.release_artefacts -%}
 {% if 'obo' in project.export_formats -%}
 $(ONT)-{{ release }}.obo: $(ONT)-{{ release }}.owl
 	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
@@ -237,7 +237,7 @@ $(ONT).json: $(ONT)-{{ project.primary_release }}.owl
 # Initiating Step: Reason over source
 # ----------------------------------------
 
-ANNOTATE_VERSION_IRI = annotate -V $(ONTBASE)/releases/`date +%Y-%m-%d`/$@.owl
+ANNOTATE_VERSION_IRI = annotate -V $(ONTBASE)/releases/$(TODAY)/$@.owl
 
 # by default we use {{ project.reasoner }} to perform a reason-relax-reduce chain
 # after that we annotate the ontology with the release versionInfo
@@ -248,7 +248,7 @@ OTHER_SRC = $(PATTERNDIR)/definitions.owl
 $(ONTOLOGYTERMS): $(SRC) all_imports
 	$(ROBOT) query --use-graphs true -f csv -i $< --query ../sparql/{{ project.id }}_terms.sparql $@
 
-{% for format in project.export_formats %} 
+{% for format in project.export_formats %}
 {% if project.gzip_main -%}
 $(ONT).{{ format }}.gz: $(ONT).{{ format }}
 	gzip -c $< > $@.tmp && mv $@.tmp $@
@@ -298,10 +298,10 @@ $(ONT)-simple.owl: $(SRC) $(OTHER_SRC) $(ONTOLOGYTERMS)
 		annotate --ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ --output $@.tmp.owl && mv $@.tmp.owl $@
 {% endif -%}
 
-{% if 'simple-non-classified' in project.release_artefacts or project.primary_release == 'simple-non-classified' -%}   
+{% if 'simple-non-classified' in project.release_artefacts or project.primary_release == 'simple-non-classified' -%}
 # foo-simple-non-classified (edit->relax,reduce,drop imports, drop every axiom which contains an entity outside the "namespaces of interest") <- aka the HPO use case, no reason.
-# Should this be the non-classified ontology with the drop foreign axiom filter? 
-# Consider adding remove --term "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace" 
+# Should this be the non-classified ontology with the drop foreign axiom filter?
+# Consider adding remove --term "http://www.geneontology.org/formats/oboInOwl#hasOBONamespace"
 
 $(ONT)-simple-non-classified.owl: $(SRC) $(OTHER_SRC) $(ONTOLOGYTERMS)
 	$(ROBOT) remove --input $< --select imports --trim true \
@@ -516,7 +516,7 @@ $(PATTERNDIR)/data/{{ pipeline.id }}/%.ofn: $(PATTERNDIR)/data/{{ pipeline.id }}
 # Generating the seed file from all the TSVs
 $(PATTERNDIR)/all_pattern_terms.txt: $(pattern_term_lists_default) {% if project.pattern_pipelines_group is defined %} {% for pipeline in project.pattern_pipelines_group.products %} $(pattern_term_lists_{{ pipeline.id }}){% endfor %}{% endif %} $(PATTERNDIR)/pattern_owl_seed.txt
 	cat $^ | sort | uniq > $@
-	
+
 $(PATTERNDIR)/pattern_owl_seed.txt: $(PATTERNDIR)/pattern.owl
 	@if [ $(IMP) = true ]; then $(ROBOT) query --use-graphs true -f csv -i $< --query ../sparql/terms.sparql $@; fi
 
@@ -524,7 +524,7 @@ $(PATTERNDIR)/data/default/%.txt: $(PATTERNDIR)/dosdp-patterns/%.yaml $(PATTERND
 	dosdp-tools terms --infile=$(word 2, $^) --template=$< --obo-prefixes=true --outfile=$@
 
 .PHONY: prepare_patterns
-prepare_patterns:	
+prepare_patterns:
 	touch $(pattern_term_lists_default) {% if project.pattern_pipelines_group is defined %} {% for pipeline in project.pattern_pipelines_group.products %} $(pattern_term_lists_{{ pipeline.id }}){% endfor %}{% endif %} &&\
   touch $(individual_patterns_default) {% if project.pattern_pipelines_group is defined %} {% for pipeline in project.pattern_pipelines_group.products %} $(individual_patterns_{{ pipeline.id }}){% endfor %}{% endif %}
 
@@ -538,9 +538,3 @@ $(PATTERNDIR)/data/{{ pipeline.id }}/%.txt: $(PATTERNDIR)/dosdp-patterns/%.yaml 
 {% endif %}
 
 include {{ project.id }}.Makefile
-
-
-
-
-
-

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -9,5 +9,4 @@
 # we therefore map the whole repo (../..) to a docker volume.
 #
 # See README-editors.md for more details.
-docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}' {% endif %} {% if project.use_external_date is sameas True %}-e TODAY='`date +%Y-%m-%d`'{% endif %}--rm -ti obolibrary/odkfull "$@"
-# Does the environment get passed in??
+docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}'{% endif %} {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d`{% endif %} --rm -ti obolibrary/odkfull "$@"

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -9,4 +9,5 @@
 # we therefore map the whole repo (../..) to a docker volume.
 #
 # See README-editors.md for more details.
-docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}' {% endif %}--rm -ti obolibrary/odkfull "$@"
+docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}' {% endif %} {% if project.use_external_date is sameas True %}-e TODAY='`date +%Y-%m-%d`'{% endif %}--rm -ti obolibrary/odkfull "$@"
+# Does the environment get passed in??


### PR DESCRIPTION
This let's the project yaml have a property called `use_external_date`, which defaults to False. 

If True, when an ontology project is created and templated, the `run.sh` will set the docker environment with 
```
TODAY=`date +%Y-%m-%d`
```
when running commands.

`TODAY` is then picked up by the Makefile in `src/ontology` to properly set the date and Version URI.