### PR TITLE
Print stdout when error occurs during seeding

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -720,6 +720,7 @@ def runcmd(cmd):
     (out, err) = p.communicate()
     logging.info('OUT: {}')
     if err:
+        logging.error(out)
         logging.error(err)
     if p.returncode != 0:
         raise Exception('Failed: {}'.format(cmd))

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -718,9 +718,8 @@ def runcmd(cmd):
     logging.info("RUNNING: {}".format(cmd))
     p = subprocess.Popen([cmd], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     (out, err) = p.communicate()
-    logging.info('OUT: {}')
+    logging.info('OUT: {}'.format(out))
     if err:
-        logging.error(out)
         logging.error(err)
     if p.returncode != 0:
         raise Exception('Failed: {}'.format(cmd))


### PR DESCRIPTION
If an error occurs during the seed command, it was sometimes impossible to tell what has caused it. Printing stdout as well as stderr might help in this case!

@althonos Can you also check this makes sense?