### PR TITLE
Creating releases on GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ venv/
 template/src/patterns/catalog-v001.xml
 .idea
 upgrade_repos.sh
+examples/phenotype-ontologies/zeco-odk-nico-curl.yaml
+examples/phenotype-ontologies/zeco-odk-nico.yaml

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CMD = ./odk/odk.py seed
 
 EMAIL_ARGS=
 
-test: test1 test2 test3 test4 test-go-mini test-patterns test-release1 test-release2 test-release3
+test: test1 test2 test3 test4 test-go-mini test-patterns test-release1 test-release2 test-release3 test-github-release
 
 test1:
 	$(CMD) $(EMAIL_ARGS) -c -d pato -t my-ontology1 myont
@@ -37,6 +37,9 @@ test-release2:
 
 test-release3:
 	$(CMD) -c -C examples/release-artefacts-test/test-release.yaml
+	
+test-github-release:
+	$(CMD) -c -C examples/tests/test-github-release.yaml
 
 schema/project-schema.json:
 	./odk/odk.py dump-schema > $@

--- a/examples/phenotype-ontologies/zeco-odk.yaml
+++ b/examples/phenotype-ontologies/zeco-odk.yaml
@@ -20,3 +20,7 @@ import_group:
   products:
     - id: ro
 robot_java_args: '-Xmx8G'
+github_release: True
+github_release_assets:
+  - zeco.owl
+github_user: matentzn

--- a/examples/tests/test-github-release.yaml
+++ b/examples/tests/test-github-release.yaml
@@ -1,0 +1,21 @@
+id: rtgh
+title: "Release Test Ontology With GH release"
+github_org: obophenotype
+repo: rta
+report_fail_on: none
+namespaces: 
+  - http://purl.obolibrary.org/obo/RTGH_
+release_artefacts: 
+  - simple
+  - base
+  - full
+primary_release: simple
+import_group:
+  products:
+    - id: ro
+    - id: pato
+    - id: mpath
+github_release: True
+github_release_assets:
+  - rtgh.owl
+github_user: matentzn

--- a/odk/make-release-assets.py
+++ b/odk/make-release-assets.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+"""
+Requires: https://github.com/PyGithub/PyGithub
+
+Command line wrapper to make github assets
+
+No download (dry-run mode), just list assets:
+
+    make-release-assets.py -k -r ontodev/robot -v v1.1.0
+
+Release files
+
+    make-release-assets.py -k -r foo/bar --release v2018-10-26 FILE1 FILE2 ... FILEn
+
+"""
+
+from github import Github
+import os
+import click
+import logging
+logging.basicConfig(level=logging.INFO)
+
+@click.command()
+@click.option("-k", "--dry-run/--no-dry-run", default=False)
+@click.option("-f", "--force/--no-force", default=False)
+@click.option("-c", "--create/--no-create", default=False)
+@click.option("-t", "--token")
+@click.option("-o", "--org")
+@click.option("-r", "--repo", default="mondo")
+@click.option("-v", "--release", default="v2018-08-24")
+@click.argument("paths", nargs=-1)
+def make_assets(dry_run, force, create, token, org, repo, release, paths):
+    if '/' in repo:
+        [org,repo] = repo.split('/')
+    if org == None:
+        org = 'monarch-initiative'
+    logging.info('org={} repo={} rel={}'.format(org, repo, release))
+    if token == None:
+        with open('.token') as f:
+            logging.info("Reading token from file")
+            token = f.read().rstrip().lstrip()
+    G = Github(token)
+    G_org = G.get_organization(org)
+    G_repo = G_org.get_repo(repo)
+
+    if create:
+        message = ""
+        if release == 'current':
+            message = "Running current release. This will be re-created with each release"
+        for r in G_repo.get_releases():
+            if r.tag_name == release:
+                if force:
+                    logging.info("Release already exists - will delete and re-create")
+                    r.delete_release()
+                else:
+                    logging.error("Release already exists!")
+                logging.info("Creating release")
+        G_repo.create_git_release(release, release, message, draft=False, prerelease=False)
+    
+    G_rel = G_repo.get_release(release)
+
+    existing_assets = {}
+    print('Existing assets:')
+    for a in G_rel.get_assets():
+        print('Asset: {} Size: {} Downloads: {}'.format(a.name, a.size, a.download_count))
+        existing_assets[a.name] = a
+
+    if (dry_run):
+        print("DRY RUN")
+    else:
+        for path in paths:
+            bn = os.path.basename(path)
+            logging.info("Testing if {} in {}".format(bn, existing_assets))
+            if bn in existing_assets.keys():
+                a = existing_assets[bn]
+                if force:
+                    logging.info("{} already exists; will replace".format(path))
+                    a.delete_asset()
+                else:
+                    logging.error("{} already exists".format(path))
+                    # TODO: if asset already exists, skip; add a --force option to explicitly overwrite
+                
+            print('Uploading: {}'.format(path))
+            a = G_rel.upload_asset(path=path)
+            print('Uploaded: {} {} from {}'.format(a.name, a.size, path))
+
+    
+if __name__ == "__main__":
+    make_assets()

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -328,8 +328,8 @@ class OntologyProject(JsonSchemaMixin):
     title : str = ""
     """Concise descriptive text about this ontology"""
 
-    github_user : str = ""
-    """GITHUB user name (necessary for generating releases)"""
+    git_user : str = ""
+    """GIT user name (necessary for generating releases)"""
 
     repo : str = ""
     """Name of repo (do not include org). E.g. cell-ontology"""
@@ -367,11 +367,11 @@ class OntologyProject(JsonSchemaMixin):
     use_dosdps : bool = False
     """if true use dead simple owl design patterns"""
 
-    github_release : bool = False
-    """if true add functions to run automated github releases (experimental)"""
+    public_release : str = 'none'
+    """if true add functions to run automated releases (experimental). Current options are: github_curl, github_python."""
 
     github_release_assets : Optional[List[str]] = None
-    """A list of files that gets added to a github release (as assets)."""
+    """A list of files that gets added to a github release (as assets). If this option is not set (None), the standard ODK assets will be deployed."""
     
     release_date : bool = False
     """if true, releases will be tagged with a release date (oboInOwl:date)"""

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -328,6 +328,9 @@ class OntologyProject(JsonSchemaMixin):
     title : str = ""
     """Concise descriptive text about this ontology"""
 
+    github_user : str = ""
+    """GITHUB user name (necessary for generating releases)"""
+
     repo : str = ""
     """Name of repo (do not include org). E.g. cell-ontology"""
     
@@ -363,6 +366,12 @@ class OntologyProject(JsonSchemaMixin):
     
     use_dosdps : bool = False
     """if true use dead simple owl design patterns"""
+
+    github_release : bool = False
+    """if true add functions to run automated github releases (experimental)"""
+
+    github_release_assets : Optional[List[str]] = None
+    """A list of files that gets added to a github release (as assets)."""
     
     release_date : bool = False
     """if true, releases will be tagged with a release date (oboInOwl:date)"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ dacite >= 0.0
 dataclasses >= 0.0
 dataclasses-json >= 0.0
 dataclasses-jsonschema >= 0.0
+PyGithub >= 0.0

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -556,4 +556,47 @@ $(PATTERNDIR)/data/{{ pipeline.id }}/%.txt: $(PATTERNDIR)/dosdp-patterns/%.yaml 
 
 {% endif %}
 
+{% if project.github_release %}
+# ----------------------------------------
+# GitHub release (HIGHLY experimental)
+# ----------------------------------------
+
+RELEASEFILES={% for gha in project.github_release_assets %} {{ gha }}{% endfor %}
+GITHUB_REPO={{ project.github_org }}/{{ project.repo }}
+TAGNAME=v$(TODAY)
+USER={{ project.github_user }}
+GH_ASSETS = $(patsubst %, tmp/gh_release_asset_%.txt, $(RELEASEFILES))
+
+tmp/release_get.txt:
+	curl -s https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${TAGNAME} > $@
+
+tmp/release_op.txt: tmp/release_get.txt
+	$(eval RELEASEID=$(shell cat tmp/release_get.txt | jq '.id'))
+	if ! [ "$(RELEASEID)" -eq "$(RELEASEID)" ] ; then \
+		curl -s -X POST \
+			https://api.github.com/repos/${GITHUB_REPO}/releases \
+			-H 'Accept: */*' \
+			-H 'Content-Type: application/json' \
+			-u ${USER} \
+			-d '{ "tag_name": "${TAGNAME}", "target_commitish": "master", "name": "${TAGNAME}", "body": "Ontology release ${TODAY}", "draft": false, "prerelease": false }' > $@; \
+	else \
+		cp $< $@; \
+	fi;
+
+tmp/gh_release_id.txt: tmp/release_op.txt
+	echo $(shell cat tmp/release_op.txt | jq '.id') > $@;
+
+tmp/gh_release_asset_%.txt: tmp/gh_release_id.txt %
+	curl -X POST \
+		"https://uploads.github.com/repos/${GITHUB_REPO}/releases/$(shell cat tmp/gh_release_id.txt)/assets?name=$*&label=$*" \
+		--data-binary @$* \
+		-u ${USER} \
+		-H 'Accept: */*' \
+		-H 'Cache-Control: no-cache' \
+		-H 'Connection: keep-alive' \
+		-H 'Content-Type: application/octet-stream' > $@
+
+gh_release: tmp/gh_release_id.txt $(GH_ASSETS)
+{% endif %}
+
 include {{ project.id }}.Makefile

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -557,16 +557,19 @@ $(PATTERNDIR)/data/{{ pipeline.id }}/%.txt: $(PATTERNDIR)/dosdp-patterns/%.yaml 
 
 {% endif %}
 
-{% if project.github_release %}
+{% if project.public_release != 'none'  %}
 # ----------------------------------------
 # GitHub release (HIGHLY experimental)
 # ----------------------------------------
 
-RELEASEFILES={% for gha in project.github_release_assets %} {{ gha }}{% endfor %}
-GITHUB_REPO={{ project.github_org }}/{{ project.repo }}
+RELEASEFILES={% if project.github_release_assets is defined -%}{% for gha in project.github_release_assets %} {{ gha }}{% endfor -%}{% else -%}$(ASSETS){% endif %}
 TAGNAME=v$(TODAY)
-USER={{ project.github_user }}
+{% endif %}
+
+{% if project.public_release == 'github_curl'  %}
+USER={{ project.git_user }}
 GH_ASSETS = $(patsubst %, tmp/gh_release_asset_%.txt, $(RELEASEFILES))
+GITHUB_REPO={{ project.github_org }}/{{ project.repo }}
 
 tmp/release_get.txt:
 	curl -s https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${TAGNAME} > $@
@@ -597,7 +600,15 @@ tmp/gh_release_asset_%.txt: tmp/gh_release_id.txt %
 		-H 'Connection: keep-alive' \
 		-H 'Content-Type: application/octet-stream' > $@
 
-gh_release: tmp/gh_release_id.txt $(GH_ASSETS)
+public_release: tmp/gh_release_id.txt $(GH_ASSETS)
+{% endif %}
+
+{% if project.public_release == 'github_python'  %}
+GITHUB_RELEASE_PYTHON=make-release-assets.py
+
+public_release:
+	ls -alt $(ASSETS)
+	$(GITHUB_RELEASE_PYTHON) --release $(TAGNAME) $(RELEASEFILES)
 {% endif %}
 
 include {{ project.id }}.Makefile


### PR DESCRIPTION
This is the first attempt to do this. It seems to work:

1) Try to retrieve a release for the current date;
2) If there add assets to that release
3) If not there, create the release, then add assets to that release

This solution is realised using the GitHub REST API (implemented with curl);  

I would like to merge this sooner rather than later to get some people to test it (I flagged it as "highly experimental" and did not connect it with the other release commands). One thing I would like to do if someone knows how to easily do it (I could find out, but dont have the bandwidth): at the moment, each call to the API requires the user to authenticate; I would like to authenticate only once, obtaining some kind of an access token, and then use that for the remaining calls. If anyone can tell me exactly how this is done, I can implement, else I am happy to move forward as is for now.