### PR TITLE
By default, a component should only be touched

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -413,8 +413,7 @@ imports/%_import.json: imports/%_import.owl
 # Some ontologies contain external and internal components. A component is included in the ontology in its entirety.
 
 {{ project.components.directory }}/%: .FORCE
-	@if [ $(IMP) = true ]; then $(ROBOT) merge -I $(URIBASE)/$* \
-	annotate --ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ -o $@; fi
+	touch $@
 .PRECIOUS: {{ project.components.directory }}/%
 
 


### PR DESCRIPTION
In a previous version, I erroneously made the default behaviour for components to pull a file from the web into the given ontology; as it turns out this would overwrite cases in which components were manually maintained and already present.