### PR TITLE
DO NOT MERGE: Add update_repo: functionality

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -712,6 +712,8 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
     tgts.append(tgt_project_file)
     if source is not None:
         copyfile(source, "{}/src/ontology/{}-edit.{}".format(outdir, project.id, project.edit_format))
+    if config is not None:
+        copyfile(config, "{}/src/ontology/{}-odk.yaml".format(outdir, project.id))
     logging.info("Created files:")
     for tgt in tgts:
         logging.info("  File: {}".format(tgt))

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -504,7 +504,11 @@ class Generator(object):
         if config_file is None:
             project = OntologyProject()
         else:
-            obj = yaml.load(config_file)
+            with open(config_file, 'r') as stream:
+                try:
+                    obj = yaml.load(stream)
+                except yaml.YAMLError as exc:
+                    print(exc)
             project = from_dict(data_class=OntologyProject, data=obj)
         if title:
             project.title = title
@@ -576,7 +580,7 @@ def cli():
     pass
 
 @cli.command()
-@click.option('-C', '--config', type=click.File('r'))
+@click.option('-C', '--config', type=click.Path(exists=True))
 @click.option('-T', '--templatedir',  default='/tools/templates/')
 @click.option('-i', '--input',  type=click.Path(exists=True))
 @click.option('-o', '--output')
@@ -589,7 +593,7 @@ def create_makefile(config, templatedir, input, output):
     print(mg.generate('{}/src/ontology/Makefile.jinja2'.format(templatedir)))
 
 @cli.command()
-@click.option('-C', '--config', type=click.File('r'))
+@click.option('-C', '--config', type=click.Path(exists=True))
 @click.option('-T', '--templatedir',  default='/tools/templates/')
 @click.option('-i', '--input',  type=click.Path(exists=True))
 @click.option('-o', '--output')
@@ -602,7 +606,7 @@ def create_dynfile(config, templatedir, input, output):
     print(mg.generate('{}/_dynamic_files.jinja2'.format(templatedir)))
     
 @cli.command()
-@click.option('-C', '--config', type=click.File('r'))
+@click.option('-C', '--config', type=click.Path(exists=True))
 @click.option('-o', '--output', required=True)
 def export_project(config, output):
     """
@@ -627,7 +631,7 @@ def dump_schema():
 
 
 @cli.command()
-@click.option('-C', '--config',       type=click.File('r'),
+@click.option('-C', '--config',       type=click.Path(exists=True),
               help="""
               path to a YAML configuration.
               See examples folder for examples.

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -645,4 +645,7 @@ public_release:
 	$(GITHUB_RELEASE_PYTHON) --release $(TAGNAME) $(RELEASEFILES)
 {% endif %}
 
+update_repo:
+	sh ../scripts/update_repo.sh
+
 include {{ project.id }}.Makefile

--- a/template/src/scripts/update_repo.sh.jinja
+++ b/template/src/scripts/update_repo.sh.jinja
@@ -1,0 +1,20 @@
+echo "This (experimental) update script will create a new repo according to your config file. It will:" 
+echo "(1) overwrite your repositories Makefile, ODK sparql queries (your custom queries wont be touched) and docker wrapper (run.sh)."
+echo "(2) and add missing files, if any."
+
+set -e
+
+OID={{project.id}}
+SRCDIR=../
+CONFIG=$OID"-odk.yaml"
+
+rm -rf target
+mkdir target
+/tools/odk.py seed -c -g False -C $CONFIG
+ls -l target/$OID/src
+ls -l $SRCDIR
+rsync -r -u --ignore-existing target/$OID/src/ $SRCDIR
+cp target/$OID/src/scripts/update_repo.sh $SRCDIR/ontology/
+cp target/$OID/src/ontology/Makefile $SRCDIR/ontology/
+cp target/$OID/src/ontology/run.sh $SRCDIR/ontology/
+cp -r target/$OID/src/sparql/* $SRCDIR/sparql/

--- a/template/src/scripts/update_repo.sh.jinja2
+++ b/template/src/scripts/update_repo.sh.jinja2
@@ -14,7 +14,7 @@ mkdir target
 ls -l target/$OID/src
 ls -l $SRCDIR
 rsync -r -u --ignore-existing target/$OID/src/ $SRCDIR
-cp target/$OID/src/scripts/update_repo.sh $SRCDIR/ontology/
+cp target/$OID/src/scripts/update_repo.sh $SRCDIR/scripts/
 cp target/$OID/src/ontology/Makefile $SRCDIR/ontology/
 cp target/$OID/src/ontology/run.sh $SRCDIR/ontology/
 cp -r target/$OID/src/sparql/* $SRCDIR/sparql/

--- a/upgrade-via-docker.sh
+++ b/upgrade-via-docker.sh
@@ -7,9 +7,11 @@ set -e
 OID=$1
 CONFIG=$2
 REPOPATH=$3
+SRCDIR=$REPOPATH/src/
 
 ./seed-via-docker.sh -c -g False -C $CONFIG
-
-cp target/$OID/src/ontology/Makefile $REPOPATH/src/ontology/
-cp target/$OID/src/ontology/run.sh $REPOPATH/src/ontology/
-cp target/$OID/src/sparql/* $REPOPATH/src/sparql/
+rsync -r -u --ignore-existing target/$OID/src/ $SRCDIR
+cp target/$OID/src/scripts/update_repo.sh $SRCDIR/scripts/
+cp target/$OID/src/ontology/Makefile $SRCDIR/ontology/
+cp target/$OID/src/ontology/run.sh $SRCDIR/ontology/
+cp -r target/$OID/src/sparql/* $SRCDIR/sparql/


### PR DESCRIPTION
This pull request will allow to dynamically update the ODK repo (makefile and associated files after changing the ontologies yaml config). This solves a bunch of problems:

1) It is currently annoying to add a new import/pattern pipeline; it requires not only to change the yaml config and run the odk seeding again, but also copying the Makefile and a bunch of empty/almost empty placeholder for imports etc.
2) When new ODK versions with improved functionality are released, it was previously annoying to update the repo because sometimes, ODK updates introduce new files. 