### PR TITLE
Update simple-seed.sparql

### DIFF
--- a/template/src/sparql/simple-seed.sparql
+++ b/template/src/sparql/simple-seed.sparql
@@ -3,6 +3,8 @@ prefix obo: <http://purl.obolibrary.org/obo/>
 
 SELECT DISTINCT ?cls WHERE
 {
+  {?cls a owl:AnnotationProperty .}
+  UNION
   {?cls a owl:ObjectProperty .}
   UNION
   {?x <http://www.geneontology.org/formats/oboInOwl#inSubset> ?cls}


### PR DESCRIPTION
Fixes the problem that annotation properties do not have metadata attached to them in the simple release by adding them to the seed selector