### PR TITLE
Add annotation: 'dc:type http://purl.obolibrary.org/obo/IAO_8000001' …

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -404,6 +404,7 @@ class OntologyProject(JsonSchemaMixin):
     """default parameters for dosdp-tools"""
     
     report_fail_on : Optional[str] = None
+#    report_fail_on : Optional[str] = "error" # this doesn't seem to have effect
     """see robot report docs for details. """
     
     travis_emails : Optional[List[Email]] = None ## ['obo-ci-reports-all@groups.io']

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -276,12 +276,13 @@ $(ONT).owl: $(ONT)-{{ project.primary_release }}.owl
 	cp $< $@
 {% endif %}
 
-
 # base: OTHER sources of interest, such as definitions owl
 $(ONT)-base.owl: $(SRC) $(OTHER_SRC)
 	$(ROBOT) remove --input $< --select imports --trim false \
 		{% if project.use_dosdps or project.components is defined %}merge $(patsubst %, -i %, $(OTHER_SRC)) \
-		{% endif %}annotate --ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ {% if project.release_date -%}--annotation oboInOwl:date "$(OBODATE)" {% endif -%}--output $@.tmp.owl && mv $@.tmp.owl $@
+		{% endif %}annotate --annotation http://purl.org/dc/elements/1.1/type http://purl.obolibrary.org/obo/IAO_8000001 \
+		--ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ \
+		{% if project.release_date -%} --annotation oboInOwl:date "$(OBODATE)" {% endif -%}--output $@.tmp.owl && mv $@.tmp.owl $@
 
 # Full: The full artefacts with imports merged, reasoned
 $(ONT)-full.owl: $(SRC) $(OTHER_SRC)


### PR DESCRIPTION
…to ontologies ending on -base.* (e.g., triffo-base.obo, triffo-base.owl).

The main change was to Makefile.jinja2. However, I also experimented with modfiying the odk.py file.
When building the base ontology, the IRI 'http://purl.obolibrary.org/obo/IAO_8000001' is specified as an xsd:string in the annotation. Should we change this to xsd:anyURI? 

I tested my changes using the "triffo" ontology described on README page. The ontologies `triffo-base.obo` and `triffo-base.owl` were annotated properly.

However, I had a very strange issue making a new odk to reflect my changes (i.e., after running `make docker-build`) in my development branch (i.e., branch `issue-296`). When I ran the command `./speed-via-docker.sh -C examples/triffo/project.yaml`, it failed.

To get around this, I create a temporary repo and ran the make on master branch. Everything worked fine.  

So, if you run into errors, try running on master branch.