### PR TITLE
WIP: Restrict imports to OWL and OBO

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -89,8 +89,13 @@ IMPORTS = {% for imp in project.import_group.products %} {{ imp.id }}{% endfor %
 IMPORTS =
 {% endif %}
 IMPORT_ROOTS = $(patsubst %, imports/%_import, $(IMPORTS))
-IMPORT_FILES = $(foreach n,$(IMPORT_ROOTS), $(foreach f,$(FORMATS), $(n).$(f)))
 IMPORT_OWL_FILES = $(foreach n,$(IMPORT_ROOTS), $(n).owl)
+{%- if project.edit_format = 'obo' %}
+IMPORT_OBO_FILES = $(foreach n,$(IMPORT_ROOTS), $(n).obo)
+IMPORT_FILES = $(IMPORT_OWL_FILES) $(IMPORT_OBO_FILES)
+{% else %}
+IMPORT_FILES = $(IMPORT_OWL_FILES)
+{% endif %}
 
 all_imports: $(IMPORT_FILES)
 {% for format in project.export_formats %}


### PR DESCRIPTION
Previously, import files were generated for every export serialisation. That made little sense. Now, imports should be OWL by default, and OBO AND OWL in case the edit file is in OBO.