### PR TITLE
added java opts ENV to run.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ docker-publish: docker-build
 	@docker push $(IM):$(VERSION) \
 	&& docker push $(IM):latest
 
-docker-test: docker-build-use-cache
+docker-test: docker-build
 	docker images | grep odkfull &&\
 	make test CMD=./seed-via-docker.sh
 

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -9,4 +9,4 @@
 # we therefore map the whole repo (../..) to a docker volume.
 #
 # See README-editors.md for more details.
-docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}'{% endif %} {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/odkfull "$@"
+docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}' -e JAVA_OPTS='{{ project.robot_java_args }}'{% endif %} {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/odkfull "$@"


### PR DESCRIPTION
This is so that the memory for dosdp can be controlled as well. I chose to use the same configuration for this as the robot_java_args - Its hard to envision a case where anyone would want to restrict the one but not the other..