### PR TITLE
Use proper versions for `fastobo-validator` in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,13 +63,14 @@ RUN wget $ROBOT_JAR -O /tools/robot.jar && \
     chmod +x /tools/robot && \
     chmod +x /tools/robot.jar
 
-# Avoid repeated downloads of script dependencies by mounting the local coursier cache: 
+# Avoid repeated downloads of script dependencies by mounting the local coursier cache:
 # docker run -v $HOME/.coursier/cache/v1:/tools/.coursier-cache ...
 ENV COURSIER_CACHE "/tools/.coursier-cache"
-    
+
 ###### FASTOBO ######
-RUN wget https://dl.bintray.com/fastobo/fastobo-validator/stable/fastobo_validator-x86_64-linux-musl.tar.gz -O- | tar xzC /tools && \
-chmod +x /tools/fastobo-validator
+ENV FASTOBO_VALIDATOR v0.3.0
+RUN wget https://dl.bintray.com/fastobo/fastobo-validator/$FASTOBO_VALIDATOR/fastobo_validator-x86_64-linux-musl.tar.gz -O- | tar xzC /tools \
+&& chmod +x /tools/fastobo-validator
 
 ##### Ammonite #####
 RUN (echo "#!/usr/bin/env sh" \


### PR DESCRIPTION
Hi! 

I recently updated `fastobo-validator` but I can't get Bintray to have the latest version it in the `stable` release, which meant the URL in the `Dockerfile` was downloading an outdated tarball. Since all the other tools in the Docker image are versioned, I also made `fastobo-validator` versioned and made sure to only download that one version.