### PR TITLE
ODK 1.2.25

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+# updated v1.2.25 (18 November 2020)
+- Updated ROBOT to new version 1.7.2, which includes some hotfixes for ROBOT report and update to whelk 1.0.4
+- Fixed a bug (https://github.com/INCATools/ontology-development-kit/issues/376) that prevented certain things (like imports and pattern generation processes) to be printed when running the Makefile.
+
 # updated v1.2.24 (6 November 2020)
 - Updated ROBOT to new version 1.7.1
 - Added the (highly experimental) ability to ODK to run OBO dashboard (see [instructions and examples](https://github.com/INCATools/ontology-development-kit#running-obo-dashboard-with-odk)).

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN wget https://github.com/konclude/Konclude/releases/download/v0.6.2-845/Koncl
     chmod +x /tools/Konclude
 
 ###### ROBOT ######
-ENV ROBOT v1.7.1
+ENV ROBOT v1.7.2
 ARG ROBOT_JAR=https://github.com/ontodev/robot/releases/download/$ROBOT/robot.jar
 ENV ROBOT_JAR ${ROBOT_JAR}
 RUN pwd

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ schema/project-schema.json:
 	./odk/odk.py dump-schema > $@
 
 # Building docker image
-VERSION = "v1.2.24"
+VERSION = "v1.2.25"
 IM=obolibrary/odkfull
 DEV=obolibrary/odkdev
 


### PR DESCRIPTION
# updated v1.2.25 (18 November 2020)
- Updated ROBOT to new version 1.7.2, which includes some hotfixes for ROBOT report and update to whelk 1.0.4
- Fixed a bug (https://github.com/INCATools/ontology-development-kit/issues/376) that prevented certain things (like imports and pattern generation proc