### PR TITLE
Bump `fastobo-validator` to v0.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN wget $ROBOT_JAR -O /tools/robot.jar && \
 ENV COURSIER_CACHE "/tools/.coursier-cache"
 
 ###### FASTOBO ######
-ENV FASTOBO_VALIDATOR v0.3.0
+ENV FASTOBO_VALIDATOR v0.4.0
 RUN wget https://dl.bintray.com/fastobo/fastobo-validator/$FASTOBO_VALIDATOR/fastobo_validator-x86_64-linux-musl.tar.gz -O- | tar xzC /tools \
 && chmod +x /tools/fastobo-validator
 


### PR DESCRIPTION
The new release:

* Adds support for line comments (i.e. comments that span on their own line, as opposed to comments at the end of a clause line, which was already supported).
* Adds a additional check (disabled by default) to ensure obsoletion clauses (`replaced_by` and `consider`) only appear in obsolete entities (`-O` flag to the CLI).