### PR TITLE
Fix build for arm64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,45 +51,51 @@ RUN apt-get update &&\
   	&& rm -r /root/.cache
 
 
-### 3. Install SWI-Prolog from source
-# First install the build-time dependencies
-RUN apt-get install -y \
-    cmake \
-    ncurses-dev \
-    libreadline-dev \
-    libedit-dev \
-    libgoogle-perftools-dev \
-    libunwind-dev \
-    libgmp-dev \
-    libssl-dev \
-    unixodbc-dev \
-    zlib1g-dev \
-    libarchive-dev \
-    libxext-dev \
-    libice-dev \
-    libjpeg-dev \
-    libxinerama-dev \
-    libxft-dev \
-    libxpm-dev \
-    libxt-dev \
-    libdb-dev \
-    libpcre3-dev \
-    libyaml-dev \
-    junit4
-
-# Then download, compile and install SWI-Prolog
-RUN wget https://www.swi-prolog.org/download/stable/src/swipl-8.2.4.tar.gz -O /tools/swipl-8.2.4.tar.gz && \
-    cd /tools && \
-    tar xf swipl-8.2.4.tar.gz && \
-    cd swipl-8.2.4 && \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
-    make && \
-    make install && \
-    cd /tools && \
-    rm swipl-8.2.4.tar.gz && \
-    rm -rf swipl-8.2.4
+### 3. Install SWI-Prolog
+# We normally install it from the binary package provided by upstream,
+# but on arm64, there is no such package and we need to build it from
+# source after installing its compile-time dependencies.
+ARG TARGETARCH
+RUN test "x$TARGETARCH" != xarm64 && ( \
+        add-apt-repository ppa:swi-prolog/stable && \
+        apt-get install -y swi-prolog \
+    ) || ( \
+        apt-get install -y \
+            cmake \
+	    ncurses-dev \
+	    libreadline-dev \
+	    libedit-dev \
+	    libgoogle-perftools-dev \
+	    libunwind-dev \
+	    libgmp-dev \
+	    libssl-dev \
+	    unixodbc-dev \
+	    zlib1g-dev \
+	    libarchive-dev \
+	    libxext-dev \
+	    libice-dev \
+	    libjpeg-dev \
+	    libxinerama-dev \
+	    libxft-dev \
+	    libxpm-dev \
+	    libxt-dev \
+	    libdb-dev \
+	    libpcre3-dev \
+	    libyaml-dev \
+	    junit4 && \
+        wget https://www.swi-prolog.org/download/stable/src/swipl-8.2.4.tar.gz -O /tools/swipl-8.2.4.tar.gz && \
+        cd /tools && \
+        tar xf swipl-8.2.4.tar.gz && \
+        cd swipl-8.2.4 && \
+        mkdir build && \
+        cd build && \
+        cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
+        make && \
+        make install && \
+        cd /tools && \
+        rm swipl-8.2.4.tar.gz && \
+        rm -rf swipl-8.2.4 \
+    )
 
 
 ### 4. Install custom tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN apt-get update &&\
     dos2unix \
     sqlite3 \
     libjson-perl \
+    libfreetype6-dev \
+    libpng-dev \
+    pkg-config \
     xlsx2csv &&\
     cd /usr/local/bin \
     && ln -s /usr/bin/python3 python \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,11 @@ COPY odk/make-release-assets.py /tools/
 # LAYERSIZE ~1000MB
 RUN apt-get update &&\
   apt-get install -y software-properties-common &&\
-  add-apt-repository ppa:swi-prolog/stable &&\
   apt-get upgrade -y &&\
   apt-get install -y build-essential \
     git \
     openjdk-8-jre \
     openjdk-8-jdk \
-    swi-prolog \
     maven \
     python3-pip \
     python3-dev \
@@ -51,6 +49,48 @@ RUN apt-get update &&\
   	&& if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi \
   	&& if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi \
   	&& rm -r /root/.cache
+
+
+### 3. Install SWI-Prolog from source
+# First install the build-time dependencies
+RUN apt-get install -y \
+    cmake \
+    ncurses-dev \
+    libreadline-dev \
+    libedit-dev \
+    libgoogle-perftools-dev \
+    libunwind-dev \
+    libgmp-dev \
+    libssl-dev \
+    unixodbc-dev \
+    zlib1g-dev \
+    libarchive-dev \
+    libxext-dev \
+    libice-dev \
+    libjpeg-dev \
+    libxinerama-dev \
+    libxft-dev \
+    libxpm-dev \
+    libxt-dev \
+    libdb-dev \
+    libpcre3-dev \
+    libyaml-dev \
+    junit4
+
+# Then download, compile and install SWI-Prolog
+RUN wget https://www.swi-prolog.org/download/stable/src/swipl-8.2.4.tar.gz -O /tools/swipl-8.2.4.tar.gz && \
+    cd /tools && \
+    tar xf swipl-8.2.4.tar.gz && \
+    cd swipl-8.2.4 && \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
+    make && \
+    make install && \
+    cd /tools && \
+    rm swipl-8.2.4.tar.gz && \
+    rm -rf swipl-8.2.4
+
 
 ### 4. Install custom tools
 #  scripts/droid

--- a/docker/robot/Dockerfile
+++ b/docker/robot/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-slim
+FROM ubuntu:18.04
 LABEL maintainer="obo-tools@googlegroups.com" 
 
 WORKDIR /tools
@@ -10,6 +10,7 @@ ENV ROBOT_JAR ${ROBOT_JAR}
 RUN apt-get update &&\
   apt-get upgrade -y &&\
   apt-get install -y make \
+    openjdk-8-jdk \
     unzip \
     rsync \
     curl


### PR DESCRIPTION
Build a M1-compatible image is currently not possible due to several issues (detailed in #413) -- mostly, the fact that some packages are not currently available as pre-compiled binary packages for the arm64 architecture.

This PR addresses those issues by:
* ensuring `matplotlib` can be compiled from source if a binary package is not available;
* changing the `obolibrary/robot` image so that it does not derive from the `openjdk:8-slim` image, which is not available for arm64;
* building SWI-Prolog from source if we're building for arm64.