### PR TITLE
Config for plant and microbial application ontology

### DIFF
--- a/configs/pamo-odk.yaml
+++ b/configs/pamo-odk.yaml
@@ -1,0 +1,26 @@
+id: pamo
+title: "Plant and Microbial Ontology"
+github_org: environmentontology
+repo: pamo-ontology
+report_fail_on: none
+release_artefacts: 
+  - base
+  - full
+  - non-classified
+primary_release: full
+export_formats:
+  - owl
+import_group:
+  products:
+    - id: ro
+      module_type: slme
+      slme_individuals: exclude
+    - id: po
+      filename: po.owl
+      source: http://purl.obolibrary.org/obo/pato/po.owl
+    - id: envo
+      filename: envo.owl
+      source: http://purl.obolibrary.org/obo/pato/envo.owl
+robot_java_args: '-Xmx12G'
+relation_graph_relations: []
+


### PR DESCRIPTION
@wdduncan will take over this PR

This is a config for a set of ontologies broadly of use for microbes and microbiomes. It includes PO as our current use case is also plant-associated biomes. We may include to other hosts later.

One of the main use cases here is building value sets via SPARQL queries - e.g. find all biomes that are not aquatic, use this as the linkml value set for soil packag biomes mixs "broad" field

We need relation-graph, we can wait for #410 or just manually inject into Makefile for now