### PR TITLE
Overhaul the Makefiles and support multi-arch builds

### DIFF
--- a/README-developers.md
+++ b/README-developers.md
@@ -134,7 +134,7 @@ image. This means that odk seed can now be run from anywhere!
 To build the Docker image from the top level:
 
 ```
-make docker-build
+make build
 ```
 
 Note that this means local invocations to use `obolibrary/odkfull`
@@ -143,14 +143,39 @@ will use the version you built.
 To test:
 
 ```
-make docker-test
+make test
 ```
 
 To publish on Dockerhub:
 
 ```
-make docker-publish
+make publish
 ```
+
+### Multi-arch images
+
+To build multi-arch images that will work seamlessly on several
+platforms, you need to have [buildx](https://github.com/docker/buildx)
+enabled on your Docker installation. On MacOS with Docker Desktop,
+`buildx` should already be enabled. For other systems, refer to Docker's
+documentation.
+
+Create a *builder* instance for multi-arch builds (this only needs to be
+done once):
+
+```
+docker buildx create --name multiarch --driver docker-container --use
+```
+
+You can then build and push multi-arch images by running:
+
+```
+make publish-multiarch
+```
+
+Use the variable `PLATFORMS` to specify the architectures for which an
+image should be built. The default is `linux/amd64,linux/arm64`, for
+images that work on both x86_64 and arm64 machines.
 
 ## Some notes on templating and logic
 

--- a/deploy_m1.sh
+++ b/deploy_m1.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-make IM=obotools/odkfull_m1 IMLITE=obotools/odklite_m1 DEV=obotools/odkdev_m1 ROB=obotools/robot_m1 docker-test
-make IM=obotools/odkfull_m1 IMLITE=obotools/odklite_m1 DEV=obotools/odkdev_m1 ROB=obotools/robot_m1 docker-publish

--- a/docker/odklite/Makefile
+++ b/docker/odklite/Makefile
@@ -1,20 +1,30 @@
 
 # Building docker image
-VERSION = "v1.2.27" 
+VERSION = "v1.2.27"
 IM=obolibrary/odklite
 
-build:
-	@docker build -t $(IM):$(VERSION) . \
-	&& docker tag $(IM):$(VERSION) $(IM):latest
+CACHE=
 
-docker-build-no-cache:
-	@docker build  --build-arg ODK_VERSION=$(VERSION) --no-cache -t $(IM):$(VERSION) . \
-	&& docker tag $(IM):$(VERSION) $(IM):latest
-	
-docker-build:
-	@docker build --build-arg ODK_VERSION=$(VERSION) -t $(IM):$(VERSION) . \
-	&& docker tag $(IM):$(VERSION) $(IM):latest
+PLATFORMS=linux/amd64,linux/arm64
+
+build:
+	docker build $(CACHE) -f Dockerfile \
+	    --build-arg ODK_VERSION=$(VERSION) \
+	    -t $(IM):$(VERSION) -t $(IM):latest \
+	    ../..
+
+build-no-cache:
+	$(MAKE) build CACHE=--no-cache
+
+publish-no-build:
+	docker push $(IM):$(VERSION)
+	docker push $(IM):latest
 
 publish: build
-	@docker push $(IM):$(VERSION) \
-	&& docker push $(IM):latest
+	$(MAKE) publish-no-build
+
+publish-multiarch:
+	docker buildx build $(CACHE) --push --platform $(PLATFORMS) \
+	    --build-arg ODK_VERSION=$(VERSION) \
+	    -t $(IM):$(VERSION) -t $(IM):latest \
+	    ../..

--- a/docker/robot/Makefile
+++ b/docker/robot/Makefile
@@ -1,16 +1,32 @@
 
 # Building docker image
-VERSION = "v1.8.1" 
+VERSION = "v1.8.1"
 IM=obolibrary/robot
 
-docker-build:
-	@docker build -t $(IM):$(VERSION) . \
-	&& docker tag $(IM):$(VERSION) $(IM):latest
+CACHE=
+
+PLATFORMS=linux/amd64,linux/arm64
+
+build:
+	docker build $(CACHE) \
+	    -t $(IM):$(VERSION) -t $(IM):latest \
+	    .
+
+build-no-cache:
+	$(MAKE) build CACHE=--no-cache
 
 clean:
-	docker kill $(IM) || echo not running ;
-	docker rm $(IM) || echo not made 
+	docker kill $(IM) || echo not running
+	docker rm $(IM) || echo not made
+
+publish-no-build:
+	docker push $(IM):$(VERSION)
+	docker push $(IM):latest
 
 publish: build
-	@docker push $(IM):$(VERSION) \
-	&& docker push $(IM):latest
+	$(MAKE) publish-no-build
+
+publish-multiarch:
+	docker buildx build $(CACHE) --push --platform $(PLATFORMS) \
+	    -t $(IM):$(VERSION) -t $(IM):latest \
+	    .


### PR DESCRIPTION
This is a proposal to add support for building multi-arch images as discussed in #421.

This PR adds a `publish-multiarch` rule to build multi-arch images (for x86_64 and arm64, for now) for all products (*odkfull*, *odklite*, *robot*) and push them on Docker Hub. A section in the README gives some details about the preliminary steps that are required on a developer's machine to enable multi-arch builds.

In addition, the Makefiles have been streamlined to reduce code duplication between rules (e.g. between `build` and `build-no-cache` rules) and to make a better use of Make's features (e.g. call `make -C docker/odklite` to build *odklite* instead of `cd` manually into the `docker/odklite` directory).

(It is still possible to use the top-level Makefile as before to build mono-arch images. `make build` will still build an image for the local architecture and `make publish` will publish that image to Docker Hub as before.)