### PR TITLE
Do not use the docker-dash branch of OBO-Dashboard.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,8 +177,8 @@ RUN swipl -g "pack_install(sparqlprog, [interactive(false)])" -g halt
 ENV PATH "/root/.local/share/swi-prolog/pack/sparqlprog/bin:$PATH"
 RUN ln -sf /root/.local/share/swi-prolog/pack/sparqlprog /tools/
 
-RUN cd /tools/ && chmod +x /tools/obodash && git clone --depth 1 --branch docker-dash https://github.com/OBOFoundry/OBO-Dashboard.git && \
-    cd OBO-Dashboard && git checkout docker-dash && echo "Dashboard: using branch |" &&\
+RUN cd /tools/ && chmod +x /tools/obodash && git clone --depth 1 https://github.com/OBOFoundry/OBO-Dashboard.git && \
+    cd OBO-Dashboard && git checkout &&\
     python3 -m pip install -r requirements.txt && echo " " >> Makefile &&\
     echo "build/robot.jar:" >> Makefile &&\
     echo "	echo 'skipped ROBOT jar download' && touch \$@" >> Makefile && echo "" >> Makefile


### PR DESCRIPTION
The docker-dash branch of OBOFoundry/OBO-Dashboard has been deleted
after being merged into master [1], thereby breaking the ODK build
because we explicitly check out that branch.

Fix the build by checking out OBO-Dashboard's master branch.

[1] https://github.com/OBOFoundry/OBO-Dashboard/pull/24