### PR TITLE
Use GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,17 @@
+name: Build the ODK images and run the tests
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Build the images
+        run: make docker-build
+      - name: Run the tests
+        run: make docker-test

--- a/seed-via-docker.sh
+++ b/seed-via-docker.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm -ti obolibrary/odkfull /tools/odk.py seed "$@"
+docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/odkfull /tools/odk.py seed "$@"


### PR DESCRIPTION
Translate the `.travis.yml` file into a Github Actions workflow to automatically build the ODK run the tests upon creating a PR against the `master` branch.

We can probably do much more with Github Actions (such as automatically push the images on Docker Hub when a release tag is created, or things like that), but the most important for now is to get CI testing back online. We can still add some fancier stuff later.