### PR TITLE
Declare odk's --skipgit option as a flag.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -760,7 +760,7 @@ def dump_schema():
               Optional. If not passed, a stub ontology will be created.
               """)
 @click.option('-v', '--verbose',      count=True)
-@click.option('-g', '--skipgit',      default=False)
+@click.option('-g', '--skipgit',      default=False, is_flag=True)
 @click.argument('repo', nargs=-1)
 def seed(config, clean, outdir, templatedir, dependencies, title, user, source, verbose, repo, skipgit):
     """


### PR DESCRIPTION
Per Click's documentation [1], boolean flags must be declared as such
with 'is_flag=True' (unless both a enabling and a disabling flags are
declared simultaneously, as in '--foo/--no-foo').

Not declaring '--skipgit' as a boolean flag causes Click to consider
that it expects an argument and may lead to some unwanted behaviours. In
particular, it can cause odk.py to always skip running the Git commands
even though the flag has *not* been specified on the command line.

[1] https://click.palletsprojects.com/en/7.x/options/#boolean-flags