### PR TITLE
Update the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -204,11 +204,6 @@ RUN cd /tools/ && chmod +x /tools/obodash && git clone --depth 1 https://github.
 ARG ODK_VERSION=0.0.0
 ENV ODK_VERSION=${ODK_VERSION}
 
-### TODO REVIEW THIS. As we speak, jq is official still stalled at 1.5, but for the walk function, we
-### Need 1.6 - once 1.6 is offcial, the following RUN can be removed.
-# LAYERSIZE: ~4MB
-RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /tools/jq && chmod +x /tools/jq
-
 COPY odk/odk.py /tools/
 COPY template/ /tools/templates/
 RUN chmod +x /tools/*.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### From https://stackoverflow.com/questions/51121875/how-to-run-docker-with-python-and-java
 ### 1. Get Linux
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="obo-tools@googlegroups.com" 
 
 ### 2. Get Java, Python and all required system libraries (version control etc)

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -1,6 +1,6 @@
 ### From https://stackoverflow.com/questions/51121875/how-to-run-docker-with-python-and-java
 ### 1. Get Linux
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="obo-tools@googlegroups.com" 
 
 ### 2. Get Java, Python and all required system libraries (version control etc)

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -51,11 +51,6 @@ RUN curl -L $ROBOT_JAR -o /tools/robot.jar &&\
 ARG ODK_VERSION=0.0.0
 ENV ODK_VERSION=${ODK_VERSION}
 
-### TODO REVIEW THIS. As we speak, jq is official still stalled at 1.5, but for the walk function, we
-### Need 1.6 - once 1.6 is offcial, the following RUN can be removed.
-# LAYERSIZE: ~4MB
-RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /tools/jq && chmod +x /tools/jq
-
 COPY odk/odk.py /tools/
 COPY template/ /tools/templates/
 RUN chmod +x /tools/*.py

--- a/docker/robot/Dockerfile
+++ b/docker/robot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="obo-tools@googlegroups.com" 
 
 WORKDIR /tools


### PR DESCRIPTION
Update the base image to the latest Ubuntu LTS (20.04).

This removes the need for manually installing `jq`, since Ubuntu 20.04 already provides a recent-enough version.