### PR TITLE
Fix running the test suite

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Build the images
         run: make build
       - name: Run the tests
-        run: make tests
+        run: make test-full

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clean:
 
 test-flavor:
 	docker images | grep odk$(FLAVOR) && \
-	    $(MAKE) test CMD=./seed-via-docker.sh
+	    $(MAKE) test CMD=./seed-via-docker.sh IMAGE=odk$(FLAVOR)
 
 test-full: build
 	$(MAKE) test-flavor FLAVOR=full

--- a/seed-via-docker.sh
+++ b/seed-via-docker.sh
@@ -2,4 +2,6 @@
 
 set -e
 
-docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/odkfull /tools/odk.py seed "$@"
+IMAGE=${IMAGE:-odkfull}
+
+docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/$IMAGE /tools/odk.py seed "$@"


### PR DESCRIPTION
The `seed-via-docker.sh` script, used to start the tests, hardcodes the name of the Docker image to use (`obolibrary/odkfull`). As a result, the Makefile rules intended to test a specific image (`test-full` to test `odkfull`, `test-dev` to test `odkdev`, `test-lite` to test `odklite`) do not work as advertised, since no matter which rule is invoked it's always the `odkfull` image that ends up being tested.

This PR fixes that by allowing to change the image used by the `seed-via-docker.sh` script.

(Of note, the `seed-via-docker.bat` script has _not_ been similarly updated, because it's been too long since I last used Windows to remember how variables work in a `.bat` script...)