### PR TITLE
Install Soufflé using a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,26 @@ RUN cd /tools/ && chmod +x /tools/obodash && git clone --depth 1 https://github.
 
 
 ###### Souffle ######
-RUN curl -s https://packagecloud.io/install/repositories/souffle-lang/souffle/script.deb.sh | bash && apt-get install -y souffle
+RUN apt-get install -y \
+    bison \
+    clang \
+    cmake \
+    doxygen \
+    flex \
+    g++ \
+    libffi-dev \
+    libncurses5-dev \
+    libsqlite3-dev \
+    mcpp \
+    sqlite \
+    zlib1g-dev && \
+    wget -O souffle-2.1.tar.gz https://github.com/souffle-lang/souffle/archive/refs/tags/2.1.tar.gz && \
+    tar xf souffle-2.1.tar.gz && \
+    cd souffle-2.1 && \
+    cmake -S . -B build && \
+    cmake --build build --target install && \
+    cd .. && \
+    rm -rf souffle-2.1.tar.gz souffle-2.1
 
 ########## DROID #########
 # LAYERSIZE ~18MB

--- a/Dockerfile
+++ b/Dockerfile
@@ -217,7 +217,7 @@ RUN cd /tools/ && chmod +x /tools/obodash && git clone --depth 1 https://github.
 
 
 ###### Souffle ######
-RUN apt-get install -y libgomp1 sqlite
+RUN apt-get install -y g++ libffi-dev libncurses5-dev libsqlite3-dev mcpp zlib1g-dev
 COPY --from=builder /tools/staging /
 
 ########## DROID #########

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,34 @@
+# Builder image for Soufflé (and possibly other programs later)
+FROM ubuntu:20.04 AS builder
+WORKDIR /tools
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+        build-essential \
+        git \
+        wget \
+        bison \
+        clang \
+        cmake \
+        doxygen \
+        flex \
+        g++ \
+        libffi-dev \
+        libncurses5-dev \
+        libsqlite3-dev \
+        mcpp \
+        sqlite \
+        lsb-release \
+        zlib1g-dev && \
+    mkdir -p staging && \
+    wget -O souffle-2.1.tar.gz https://github.com/souffle-lang/souffle/archive/refs/tags/2.1.tar.gz && \
+    tar xf souffle-2.1.tar.gz && \
+    cd souffle-2.1 && \
+    cmake -S . -B build && \
+    cmake --build build --target install DESTDIR=/tools/staging && \
+    cd .. && \
+    rm -rf souffle-2.1.tar.gz souffle-2.1
+
 ### From https://stackoverflow.com/questions/51121875/how-to-run-docker-with-python-and-java
 ### 1. Get Linux
 FROM ubuntu:20.04
@@ -186,26 +217,8 @@ RUN cd /tools/ && chmod +x /tools/obodash && git clone --depth 1 https://github.
 
 
 ###### Souffle ######
-RUN apt-get install -y \
-    bison \
-    clang \
-    cmake \
-    doxygen \
-    flex \
-    g++ \
-    libffi-dev \
-    libncurses5-dev \
-    libsqlite3-dev \
-    mcpp \
-    sqlite \
-    zlib1g-dev && \
-    wget -O souffle-2.1.tar.gz https://github.com/souffle-lang/souffle/archive/refs/tags/2.1.tar.gz && \
-    tar xf souffle-2.1.tar.gz && \
-    cd souffle-2.1 && \
-    cmake -S . -B build && \
-    cmake --build build --target install && \
-    cd .. && \
-    rm -rf souffle-2.1.tar.gz souffle-2.1
+RUN apt-get install -y libgomp1 sqlite
+COPY --from=builder /tools/staging /
 
 ########## DROID #########
 # LAYERSIZE ~18MB

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,10 @@ RUN cd /tools/ && chmod +x /tools/obodash && git clone --depth 1 https://github.
     echo "build/robot.jar:" >> Makefile &&\
     echo "	echo 'skipped ROBOT jar download' && touch \$@" >> Makefile && echo "" >> Makefile
 
+
+###### Souffle ######
+RUN curl -s https://packagecloud.io/install/repositories/souffle-lang/souffle/script.deb.sh | bash && apt-get install -y souffle
+
 ########## DROID #########
 # LAYERSIZE ~18MB
 #RUN apt-get install -y leiningen


### PR DESCRIPTION
This PR uses the problem of adding Soufflé to the ODK (#459) as an opportunity to test multi-stage builds (#466).

Soufflé is built on an intermediate image containing all its required build-time dependencies, and only the compiled program and its run-time dependencies are installed to the final ODK image. With all the build-time dependencies left out of the final image, the size increase due to the addition of Soufflé is minimal (~15 Mb).

@balhoff Can you build the ODK from this PR and test that Soufflé is working as you expect? Or provide some tests that I could use to check myself?