### PR TITLE
ensure_owl2dl_profile should be True by default

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -299,7 +299,7 @@ class ReportConfig(JsonSchemaMixin):
     report_on : List[str] = field(default_factory=lambda: ['edit'])
     """Chose which files to run the report on."""
     
-    ensure_owl2dl_profile : bool = False
+    ensure_owl2dl_profile : bool = True
     """This will ensure that the main .owl release file conforms to the owl2 profile during make test."""
     
     release_reports : bool = False


### PR DESCRIPTION
I can't think of any situation where we want to disable this; if it does exist it will be an advanced user who will be capable of making the change