### PR TITLE
Move to Java 11.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV COURSIER_CACHE "/tools/.coursier-cache"
 # Install tools provided by Ubuntu.
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
     build-essential \
-    openjdk-8-jdk-headless \
+    openjdk-11-jdk-headless \
     maven \
     python3-dev \
     subversion \

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -19,7 +19,7 @@ ENV ODK_VERSION $ODK_VERSION
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
         git \
-        openjdk-8-jre-headless \
+        openjdk-11-jre-headless \
         python3-pip \
         python-is-python3 \
         make \

--- a/docker/robot/Dockerfile
+++ b/docker/robot/Dockerfile
@@ -10,7 +10,7 @@ ENV ROBOT_JAR ${ROBOT_JAR}
 RUN apt-get update &&\
   apt-get upgrade -y &&\
   apt-get install -y --no-install-recommends make \
-    openjdk-8-jre-headless \
+    openjdk-11-jre-headless \
     unzip \
     rsync \
     curl


### PR DESCRIPTION
I propose we move to Java 11. It's been out as the LTS version for 3 years. Some libraries are starting to drop compatibility with Java 8 (e.g., Jena 4.x). In my experience Java 11 has better performance as well. Making the change here doesn't force any particular tool (like ROBOT) to drop support for Java 8.