### PR TITLE
Update the run.sh wrapper to display runtime stats.

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update && \
         wget \
         curl \
         jq \
-        rsync
+        rsync \
+        time
 
 # Install Python environment (copied over from the builder image).
 COPY --from=obolibrary/odkbuild:latest /staging/lite /

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -12,4 +12,14 @@
 
 IMAGE=${IMAGE:-odkfull}
 
-docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}' -e JAVA_OPTS='{{ project.robot_java_args }}'{% endif %} {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/$IMAGE "$@"
+ODK_DEBUG=${ODK_DEBUG:-no}
+
+TIMECMD=
+if [ x$ODK_DEBUG = xyes ]; then
+    # If you wish to change the format string, take care of using
+    # non-breaking spaces (U+00A0) instead of normal spaces, to
+    # prevent the shell from tokenizing the format string.
+    TIMECMD="/usr/bin/time -f ### DEBUG STATS ###\nElapsed time: %E\nPeak memory: %M kb"
+fi
+
+docker run -v $PWD/../../:/work -w /work/src/ontology {% if project.robot_java_args is defined %}-e ROBOT_JAVA_ARGS='{{ project.robot_java_args }}' -e JAVA_OPTS='{{ project.robot_java_args }}'{% endif %} {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/$IMAGE $TIMECMD "$@"


### PR DESCRIPTION
Add the `time` package to odklite. Use the provided `time` command in the run.sh wrapper to print elapsed time and peak memory consumption of the invoked command in the container.

The feature is conditional on the variable `ODK_DEBUG` being set to `yes` when invoking the wrapper. Either set at the time of invocation:

```sh
$ ODK_DEBUG=yes ./run.sh make prepare_release
[... normal output of "make prepare_release" ...]
### DEBUG STATS ###
Elapsed time: 0:55.75
Peak memory: 4407880 kb
```

or to always get the stats, export `ODK_DEBUG` in the shell environment:

```sh
$ export ODK_DEBUG=yes
$ ./run.sh make prepare_release
[... normal output of "make prepare_release" ...]
### DEBUG STATS ###
Elapsed time: 0:55.75
Peak memory: 4407880 kb
```