### PR TITLE
Make 'allow_equivalents' default to 'asserted-only'.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -491,8 +491,8 @@ class OntologyProject(JsonSchemaMixin):
     release_date : bool = False
     """if true, releases will be tagged with a release date (oboInOwl:date)"""
     
-    allow_equivalents : str = "assert-only"
-    """can be all, none or assert-only (see ROBOT documentation: http://robot.obolibrary.org/reason)"""
+    allow_equivalents : str = "asserted-only"
+    """can be all, none or asserted-only (see ROBOT documentation: http://robot.obolibrary.org/reason)"""
     
     ci : Optional[List[str]] = field(default_factory=lambda: ['github_actions'])
     """continuous integration defaults; currently available: travis, github_actions"""

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -491,7 +491,7 @@ class OntologyProject(JsonSchemaMixin):
     release_date : bool = False
     """if true, releases will be tagged with a release date (oboInOwl:date)"""
     
-    allow_equivalents : str = "all"
+    allow_equivalents : str = "assert-only"
     """can be all, none or assert-only (see ROBOT documentation: http://robot.obolibrary.org/reason)"""
     
     ci : Optional[List[str]] = field(default_factory=lambda: ['github_actions'])

--- a/tests/test-module-mirror.yaml
+++ b/tests/test-module-mirror.yaml
@@ -10,4 +10,5 @@ import_group:
   products:
     - id: envo
       module_type: mirror
+allow_equivalents: all
 


### PR DESCRIPTION
We want to promote the avoidance of inferred equivalencies, so we switch the `allow_equivalents` setting from its default value of `all` (default value for the `--equivalent-classes-allowed` of ROBOT’s `explain` command) to `asserted-only`.

See Chris Mungall’s [blog post](https://douroucouli.wordpress.com/2018/09/04/debugging-ontologies-using-owl-reasoning-part-2-unintentional-entailed-equivalence/) for more information on the rationale for this switch.

This PR only changes the _default_ value and therefore won’t affect the ontologies that have set an explicit value for the `allow_equivalents` setting in their `src/ontology/$OID-odk.yaml` file. Ontologies that were relying on the previous default value of `all` may need to update their configuration to explicitly set `allow_equivalents` to `all`, if they happen to contain non-asserted inferred equivalencies that they need to keep (or cannot remove).