### PR TITLE
Make $(SRCMERGED) depend on $(OTHER_SRC).

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -227,7 +227,7 @@ IMPORTSEED=$(TMPDIR)/seed.txt
 SRCMERGED=$(TMPDIR)/merged-$(SRC)
 PRESEED=$(TMPDIR)/pre_seed.txt
 
-$(SRCMERGED): $(SRC)
+$(SRCMERGED): $(SRC) $(OTHER_SRC)
 	$(ROBOT) remove --input $< --select imports --trim false \
 		merge  $(patsubst %, -i %, $(OTHER_SRC)) -o $@
 


### PR DESCRIPTION
The entire point of the rule generating the `$(SRCMERGED)` file is to merge any component listed in `$(OTHER_SRC)`, so that rule should depend on `$(OTHER_SRC)` in addition to `$(SRC)`, so that any changes in a component can trigger a rebuild of `$(SRCMERGED)`.