### PR TITLE
Fix validation of DOSDP patterns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ mkdocs-material
 funowl
 kgx
 linkml
+dosdp

--- a/requirements.txt.lite
+++ b/requirements.txt.lite
@@ -9,3 +9,4 @@ jsonschema
 PyGithub
 pyyaml
 ruamel.yaml
+dosdp

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -59,7 +59,7 @@ ONTOLOGYTERMS =             $(TMPDIR)/ontologyterms.txt
 {%- if project.use_dosdps %}
 PATTERNDIR=                 ../patterns
 DOSDP_SCHEMA=                http:// # change to PURL when ready.
-PATTERN_TESTER=              simple_pattern_tester.py
+PATTERN_TESTER=              dosdp validate -i
 DOSDPT=                      dosdp-tools
 PATTERN_RELEASE_FILES=       $(PATTERNDIR)/definitions.owl $(PATTERNDIR)/pattern.owl
 

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -79,7 +79,7 @@ RELEASE_ARTEFACTS = $(sort {% for release in project.release_artefacts %}{% if r
 all: odkversion all_imports {% if project.use_dosdps %}patterns {% endif %}all_main all_subsets sparql_test all_reports all_assets
 
 .PHONY: test
-test: odkversion sparql_test all_reports {% if project.robot_report.ensure_owl2dl_profile %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
+test: odkversion sparql_test {% if project.use_dosdps %}pattern_schema_checks {% endif %}all_reports {% if project.robot_report.ensure_owl2dl_profile %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
 	$(ROBOT) reason --input $(SRC) --reasoner {{ project.reasoner }}  --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} --output test.owl && rm test.owl && echo "Success"
 
 .PHONY: odkversion


### PR DESCRIPTION
This PR:

* changes the validator used to check DOSDP patterns from the `simple_pattern_tester.py` script to the `dosdp validate` command from the `dosdp` Python module.
* makes sure that DOSDP patterns, if enabled, are checked as part of the standard test suite, as invoked by `make test`.