### PR TITLE
Build rdftab from source.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,8 +108,3 @@ RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RG/re
 && tar -zxvf relation-graph-$RG.tgz \
 && mv relation-graph-$RG /tools/relation-graph \
 && chmod +x /tools/relation-graph
-
-# rdftab
-ENV RDFTAB=0.1.1
-RUN wget -nv https://github.com/ontodev/rdftab.rs/releases/download/v$(RSDTAB)/rdftab-x86_64-unknown-linux-musl -O /tools/rdftab \
-&& chmod +x /tools/rdftab

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -118,6 +118,16 @@ RUN wget -nv https://github.com/fastobo/fastobo-validator/archive/refs/tags/v0.4
     cd /build && \
     rm -rf fastobo-validator-0.4.0 fastobo-validator-0.4.0.tar.gz /root/.cargo
 
+# Compile rdftab.
+RUN wget -nv https://github.com/ontodev/rdftab.rs/archive/refs/tags/v0.1.1.tar.gz \
+        -O /build/rdftab-0.1.1.tar.gz && \
+    tar xf rdftab-0.1.1.tar.gz && \
+    cd rdftab.rs-0.1.1 && \
+    cargo build --release && \
+    install -D -m 755 target/release/rdftab /staging/full/usr/bin/rdftab && \
+    cd /build && \
+    rm -rf rdftab.rs-0.1.1 rdftab-0.1.1.tar.gz /root/.cargo
+
 # Compile Konclude if we are not on x86_64
 # (building Konclude is time-consuming, so we avoid it
 #  on x86_64 where a pre-compiled binary is available).

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -6,6 +6,9 @@
 FROM ubuntu:20.04
 WORKDIR /build
 
+# Software versions
+ENV RDFTAB_VERSION=0.1.1
+
 # Everything that we want to get into one of the final ODK images
 # should be installed into one of these directories.
 RUN mkdir -p /staging/lite /staging/full
@@ -119,14 +122,14 @@ RUN wget -nv https://github.com/fastobo/fastobo-validator/archive/refs/tags/v0.4
     rm -rf fastobo-validator-0.4.0 fastobo-validator-0.4.0.tar.gz /root/.cargo
 
 # Compile rdftab.
-RUN wget -nv https://github.com/ontodev/rdftab.rs/archive/refs/tags/v0.1.1.tar.gz \
-        -O /build/rdftab-0.1.1.tar.gz && \
-    tar xf rdftab-0.1.1.tar.gz && \
-    cd rdftab.rs-0.1.1 && \
+RUN wget -nv https://github.com/ontodev/rdftab.rs/archive/refs/tags/v$RDFTAB_VERSION.tar.gz \
+        -O /build/rdftab.tar.gz && \
+    tar xf rdftab.tar.gz && \
+    cd rdftab.rs-$RDFTAB_VERSION && \
     cargo build --release && \
     install -D -m 755 target/release/rdftab /staging/full/usr/bin/rdftab && \
     cd /build && \
-    rm -rf rdftab.rs-0.1.1 rdftab-0.1.1.tar.gz /root/.cargo
+    rm -rf rdftab.rs-$RDFTAB_VERSION rdftab.tar.gz /root/.cargo
 
 # Compile Konclude if we are not on x86_64
 # (building Konclude is time-consuming, so we avoid it


### PR DESCRIPTION
This PR amends #590 to install `rdftab` by compiling it from source, as no pre-built `rdftab` binary for arm64 is available (yet?).