### PR TITLE
Allow to only push `dev`-tagged images to Docker Hub.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,15 @@ schema/project-schema.json:
 VERSION = "v1.3.2"
 IM=obolibrary/odkfull
 IMLITE=obolibrary/odklite
-DEV=obolibrary/odkdev
 ROB=obolibrary/robot
 #ROBOT_JAR="https://github.com/monarch-ebi-dev/odk_utils/raw/master/robot_maven_test.jar"
 ROBOT_JAR_ARGS=#--build-arg ROBOT_JAR=$(ROBOT_JAR)
+TAGS_OPTION=-t $(IM):$(VERSION) -t $(IM):latest
 
 build: build-odklite
 	docker build $(CACHE) --platform $(ARCH) \
 	    --build-arg ODK_VERSION=$(VERSION) $(ROBOT_JAR_ARGS) \
-	    -t $(IM):$(VERSION) -t $(IM):latest -t $(DEV):latest \
+	    $(TAGS_OPTION) \
 	    .
 
 build-odklite: build-builder
@@ -84,10 +84,11 @@ build-builder:
 build-no-cache:
 	$(MAKE) build CACHE=--no-cache
 
-build-dev:
-	docker build --build-arg ODK_VERSION=$(VERSION) --platform $(ARCH) \
-	    -t $(DEV):$(VERSION) -t $(DEV):latest \
-	    .
+build-odklite-dev: build-builder
+	$(MAKE) TAGS_OPTION="-t $(IMLITE):dev" VERSION=$(VERSION)-dev build-odklite
+
+build-dev: build-odklite-dev
+	$(MAKE) TAGS_OPTION="-t $(IM):dev" VERSION=$(VERSION)-dev build
 
 clean:
 	docker kill $(IM) || echo not running
@@ -107,20 +108,14 @@ test-flavor:
 test-full: build
 	$(MAKE) test-flavor FLAVOR=full
 
-test-dev: build-dev
-	$(MAKE) test-flavor FLAVOR=dev
-
 test-lite: build-odklite
 	$(MAKE) test-flavor FLAVOR=lite
 
-tests: test-full test-dev
+tests: test-full
 	make test_odkfull_programs
 
 test-no-build:
 	$(MAKE) test-flavor FLAVOR=full
-
-test-dev-no-build:
-	$(MAKE) test-flavor FLAVOR=dev
 
 test-lite-no-build:
 	$(MAKE) test-flavor FLAVOR=lite
@@ -130,17 +125,12 @@ test-lite-no-build:
 
 publish-no-build:
 	docker push $(DEV):$(VERSION)
-	docker push $(DEV):latest
 	docker push $(IM):latest
 	docker push $(IM):$(VERSION)
 	$(MAKE) -C docker/odklite publish-no-build
 
 publish: build
 	$(MAKE) publish-no-build
-
-publish-dev-no-build:
-	docker push $(DEV):$(VERSION)
-	docker push $(DEV):latest
 
 publish-multiarch:
 	$(MAKE) -C docker/robot CACHE=$(CACHE) PLATFORMS=$(PLATFORMS) \
@@ -152,8 +142,20 @@ publish-multiarch:
 	    publish-multiarch
 	docker buildx build $(CACHE) --push --platform $(PLATFORMS) \
 	    --build-arg ODK_VERSION=$(VERSION) \
-	    -t $(IM):$(VERSION) -t $(IM):latest -t $(DEV):latest \
+	    $(TAGS_OPTION) \
 	    .
+
+publish-multiarch-dev:
+	$(MAKE) -C docker/builder CACHE=$(CACHE) PLATFORMS=$(PLATFORMS) \
+		publish-multiarch
+	$(MAKE) -C docker/odklite IM=$(IMLITE) VERSION=$(VERSION)-dev \
+		CACHE=$(CACHE) PLATFORMS=$(PLATFORMS) \
+		TAGS_OPTION="-t $(IMLITE):dev" \
+		publish-multiarch
+	docker buildx build $(CACHE) --push --platform $(PLATFORMS) \
+		--build-arg ODK_VERSION=$(VERSION)-dev \
+		-t $(IM):dev \
+		.
 
 clean-tests:
 	rm -rf target/*

--- a/docker/odklite/Makefile
+++ b/docker/odklite/Makefile
@@ -2,6 +2,7 @@
 # Building docker image
 VERSION = "v1.2.30"
 IM=obolibrary/odklite
+TAGS_OPTION=-t $(IM):$(VERSION) -t $(IM):latest
 
 CACHE=
 
@@ -11,7 +12,7 @@ PLATFORMS=linux/amd64,linux/arm64
 build:
 	docker build $(CACHE) --platform $(ARCH) -f Dockerfile \
 	    --build-arg ODK_VERSION=$(VERSION) \
-	    -t $(IM):$(VERSION) -t $(IM):latest \
+	    $(TAGS_OPTION) \
 	    ../..
 
 build-no-cache:
@@ -27,5 +28,5 @@ publish: build
 publish-multiarch:
 	docker buildx build $(CACHE) --push --platform $(PLATFORMS) -f Dockerfile \
 	    --build-arg ODK_VERSION=$(VERSION) \
-	    -t $(IM):$(VERSION) -t $(IM):latest \
+	    $(TAGS_OPTION) \
 	    ../..


### PR DESCRIPTION
This PR adds a new main target to the top-level Makefile: `publish-multiarch-dev`. This target builds multi-architecture images of `odkfull` and `odklite`,¹ tag them with a `dev` tag, and publish them to the Docker Hub.

Inside the `dev` images, the ODK has version number `$(VERSION)-dev`, to allow users who may use alternatively a `dev` image and a released image to know which one they are using at any time.

With `dev` tagged images (`obolibrary/odkfull:dev`), the `obolibrary/odkdev` image becomes redundant and this PR removes it. The `build-dev` target, which uses to build the `odkdev` image, now builds `odkfull:dev`.

closes #648 

¹ Building and pushing `odklite:dev` is necessary even if we only need `odkfull:dev`, since `odkfull` is built on top of `odklite`.