### PR TITLE
Rename IMAGE to ODK_IMAGE in the run.sh script.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v1.3.2 (unpublished, target date 31 July 2022)
 
+- Changes in the `src/ontology/run.sh` wrapper script:
+  - [It is now possible](https://github.com/INCATools/ontology-development-kit/pull/640) to execute the Docker image through [Singularity](https://apptainer.org).
+  - The `IMAGE` variable, which can used to specify an alternative ODK image, [has been renamed](https://github.com/INCATools/ontology-development-kit/pull/655) to `ODK_IMAGE`.
+  - A new variable `ODK_TAG` has been introduced, allowing to specify an alternative tag (default is `latest`). A tag may also be specified directly as part of the `ODK_IMAGE` variable (as in `ODK_IMAGE=odkfull:v1.3.1`).
+
 # v1.3.1
 
 - [Update to ROBOT 1.9.0](https://github.com/INCATools/ontology-development-kit/pull/621), see [ROBOT release notes](https://github.com/ontodev/robot/releases/tag/v1.9.0). One major change concerning ODK: the [OBOGraphs JSON serialiser](https://github.com/geneontology/obographs) has been updated significantly, which means obographs json files may look a bit different. Most important change: empty elements (xrefs) are no longer serialised.

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,8 @@ clean:
 
 test-flavor:
 	@if docker images | grep -q odk$(FLAVOR) ; then \
-		$(MAKE) test_odk$(FLAVOR)_programs IMAGE=odk$(FLAVOR) ; \
-		$(MAKE) test CMD=./seed-via-docker.sh IMAGE=odk$(FLAVOR) ; \
+		$(MAKE) test_odk$(FLAVOR)_programs ODK_IMAGE=odk$(FLAVOR) ; \
+		$(MAKE) test CMD=./seed-via-docker.sh ODK_IMAGE=odk$(FLAVOR) ; \
 	else \
 		echo "Image obolibrary/odk$(FLAVOR) not locally available" ; \
 	fi

--- a/seed-via-docker.sh
+++ b/seed-via-docker.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-IMAGE=${IMAGE:-odkfull}
+ODK_IMAGE=${ODK_IMAGE:-odkfull}
 
-docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/$IMAGE /tools/odk.py seed "$@"
+docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE /tools/odk.py seed "$@"

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -14,14 +14,14 @@
 #
 # See README-editors.md for more details.
 
-IMAGE=${IMAGE:-odkfull}
-TAG_IN_IMAGE=$(echo $IMAGE | awk -F':' '{ print $2 }')
+ODK_IMAGE=${ODK_IMAGE:-odkfull}
+TAG_IN_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $2 }')
 if [ "$TAG_IN_IMAGE" ]; then
-  # Override TAG env var if IMAGE already includes a tag
-  TAG=$TAG_IN_IMAGE
-  IMAGE=$(echo $IMAGE | awk -F':' '{ print $1 }')
+  # Override ODK_TAG env var if IMAGE already includes a tag
+  ODK_TAG=$TAG_IN_IMAGE
+  ODK_IMAGE=$(echo $IMAGE | awk -F':' '{ print $1 }')
 fi
-TAG=${TAG:-latest}
+ODK_TAG=${ODK_TAG:-latest}
 ODK_JAVA_OPTS={% if project.robot_java_args is defined and project.robot_java_args|length %}${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}{% else %}${ODK_JAVA_OPTS:--Xmx8G}{% endif %}
 ODK_DEBUG=${ODK_DEBUG:-no}
 
@@ -43,9 +43,9 @@ if [ -n "$USE_SINGULARITY" ]; then
         --env "ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS,JAVA_OPTS=$ODK_JAVA_OPTS" \
         --bind $VOLUME_BIND \
         -W $WORK_DIR \
-        docker://obolibrary/$IMAGE:$TAG $TIMECMD "$@"
+        docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 else
-    docker run -v $VOLUME_BIND -w $WORK_DIR -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/$IMAGE $TIMECMD "$@"
+    docker run -v $VOLUME_BIND -w $WORK_DIR -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 fi
 
 case "$@" in

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -16,10 +16,10 @@
 
 ODK_IMAGE=${ODK_IMAGE:-odkfull}
 TAG_IN_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $2 }')
-if [ "$TAG_IN_IMAGE" ]; then
+if [ -n "$TAG_IN_IMAGE" ]; then
   # Override ODK_TAG env var if IMAGE already includes a tag
   ODK_TAG=$TAG_IN_IMAGE
-  ODK_IMAGE=$(echo $IMAGE | awk -F':' '{ print $1 }')
+  ODK_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $1 }')
 fi
 ODK_TAG=${ODK_TAG:-latest}
 ODK_JAVA_OPTS={% if project.robot_java_args is defined and project.robot_java_args|length %}${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}{% else %}${ODK_JAVA_OPTS:--Xmx8G}{% endif %}


### PR DESCRIPTION
In the run.sh wrapper script, rename the `IMAGE` variable to `ODK_IMAGE`. This is for consistency with the other variables in that script such as `ODK_DEBUG` and `ODK_JAVA_OPTS`. Likewise for `TAG`, renamed to `ODK_TAG`.

This will allow ODK users/developers who always want to use a specific image to safely export `ODK_IMAGE=...` and/or `ODK_TAG=...` in in their profile scripts, without fearing that it could interfere with any other program that might look for a `IMAGE` or `TAG` environment variable.

Likewise for the `seed-via-docker.sh` script, again for consistency.