### PR TITLE
Build `odkfull:dev` from `odklite:dev`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Final ODK image
 # (built upon the odklite image)
-FROM obolibrary/odklite:latest
+ARG ODKLITE_TAG=latest
+FROM obolibrary/odklite:${ODKLITE_TAG}
 LABEL maintainer="obo-tools@googlegroups.com"
 
 ENV PATH "/tools/apache-jena/bin:/tools/sparqlprog/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,12 @@ build-odklite-dev: build-builder
 	$(MAKE) TAGS_OPTION="-t $(IMLITE):dev" VERSION=$(VERSION)-dev build-odklite
 
 build-dev: build-odklite-dev
-	$(MAKE) TAGS_OPTION="-t $(IM):dev" VERSION=$(VERSION)-dev build
+	docker build $(CACHE) --platform $(ARCH) \
+		--build-arg ODK_VERSION=$(VERSION)-dev \
+		--build-arg ODKLITE_TAG=dev \
+		$(ROBOT_JAR_ARGS) \
+		-t $(IM):dev \
+		.
 
 clean:
 	docker kill $(IM) || echo not running
@@ -154,6 +159,7 @@ publish-multiarch-dev:
 		publish-multiarch
 	docker buildx build $(CACHE) --push --platform $(PLATFORMS) \
 		--build-arg ODK_VERSION=$(VERSION)-dev \
+		--build-arg ODKLITE_TAG=dev \
 		-t $(IM):dev \
 		.
 


### PR DESCRIPTION
Update the main Dockerfile to allow to specify a different `odklite` version to build `odkfull` from, instead of always building from `odklite:latest`.

Update the main Makefile so that the `build-dev` and `publish-multiarch-dev` rules build the `odkfull:dev` image from `odklite:dev`, so that the resulting image does contain all the latest changes as intended.

closes #659