### PR TITLE
Make sure the Python package `six` is present in `odklite`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ test_odklite_programs:
 	@./tests/test-program.sh DOSDP-TOOLS dosdp-tools -v
 	@./tests/test-program.sh OWLTOOLS owltools --version
 	@./tests/test-program.sh AMMONITE sh amm --help
+	@./tests/test-program.sh ODK odk.py
 
 test_odkfull_programs: test_odklite_programs
 	@./tests/test-program.sh KONCLUDE Konclude -h

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
         openjdk-11-jre-headless \
         python3-pip \
         python-is-python3 \
+        python3-six \
         make \
         unzip \
         wget \

--- a/seed-via-docker.sh
+++ b/seed-via-docker.sh
@@ -3,5 +3,6 @@
 set -e
 
 ODK_IMAGE=${ODK_IMAGE:-odkfull}
+ODK_TAG=${ODK_TAG:-latest}
 
-docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE /tools/odk.py seed "$@"
+docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE:$ODK_TAG /tools/odk.py seed "$@"

--- a/tests/test-program.sh
+++ b/tests/test-program.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 ODK_IMAGE=${ODK_IMAGE:-odkfull}
+ODK_TAG=${ODK_TAG:-latest}
 
 program_name=$1; shift
 echo -n "Checking for $program_name... "
-docker run --rm -ti obolibrary/$IMAGE $@ >/dev/null && echo OK || echo KO
+docker run --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $@ >/dev/null && echo OK || echo KO

--- a/tests/test-program.sh
+++ b/tests/test-program.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=${IMAGE:-odkfull}
+ODK_IMAGE=${ODK_IMAGE:-odkfull}
 
 program_name=$1; shift
 echo -n "Checking for $program_name... "


### PR DESCRIPTION
The `odklite` image is missing the Python `six` package, which is needed by the `odk.py` script.

The problem is that the Debian meta-package `build-essential` automatically installs `python3-six`. As a result, when we install the Python packages when building `odkbuild`, `pip` does _not_ install `six`, since it is already available in `/usr/lib/python3/dist-packages`. So the staging area in `odkbuild` contains no trace of `six`, which is then absent from `odklite`.

The problem does not affect `odkfull` because in `odkfull`, we _also_ install the `build-essential` meta-package, which brings in `python3-six`.

The fix is simply to explicitly install `python3-six` in the `odklite` image.

closes #665