### PR TITLE
fixed parentheses in inject queries

### DIFF
--- a/template/src/sparql/inject-subset-declaration.ru.jinja2
+++ b/template/src/sparql/inject-subset-declaration.ru.jinja2
@@ -7,5 +7,5 @@ INSERT { ?y rdfs:subPropertyOf <http://www.geneontology.org/formats/oboInOwl#Sub
 WHERE {
   ?x <http://www.geneontology.org/formats/oboInOwl#inSubset>  ?y .
   FILTER(isIRI(?y))
-  FILTER(regex(str(?y),"^(http://purl.obolibrary.org/obo/)") || regex(str(?y),"^(http://www.ebi.ac.uk/efo/)") || regex(str(?y),"^(https://w3id.org/biolink/)" || regex(str(?y),"^({{ project.uribase }})")))
+  FILTER(regex(str(?y),"^(http://purl.obolibrary.org/obo/)") || regex(str(?y),"^(http://www.ebi.ac.uk/efo/)") || regex(str(?y),"^(https://w3id.org/biolink/)") || regex(str(?y),"^({{ project.uribase }})"))
 }

--- a/template/src/sparql/inject-synonymtype-declaration.ru.jinja2
+++ b/template/src/sparql/inject-synonymtype-declaration.ru.jinja2
@@ -7,5 +7,5 @@ INSERT { ?y rdfs:subPropertyOf <http://www.geneontology.org/formats/oboInOwl#Syn
 WHERE {
   ?x <http://www.geneontology.org/formats/oboInOwl#hasSynonymType>  ?y .
   FILTER(isIRI(?y))
-  FILTER(regex(str(?y),"^(http://purl.obolibrary.org/obo/)") || regex(str(?y),"^(http://www.ebi.ac.uk/efo/)") || regex(str(?y),"^(https://w3id.org/biolink/)" || regex(str(?y),"^({{ project.uribase }})")))
+  FILTER(regex(str(?y),"^(http://purl.obolibrary.org/obo/)") || regex(str(?y),"^(http://www.ebi.ac.uk/efo/)") || regex(str(?y),"^(https://w3id.org/biolink/)") || regex(str(?y),"^({{ project.uribase }})"))
 }


### PR DESCRIPTION
Moved ")" so that the last regex function is not inside the previous regex function.