### PR TITLE
Allow extra volume bindings and custom wrapper config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - [It is now possible](https://github.com/INCATools/ontology-development-kit/pull/640) to execute the Docker image through [Singularity](https://apptainer.org).
   - The `IMAGE` variable, which can used to specify an alternative ODK image, [has been renamed](https://github.com/INCATools/ontology-development-kit/pull/655) to `ODK_IMAGE`.
   - A new variable `ODK_TAG` has been introduced, allowing to specify an alternative tag (default is `latest`). A tag may also be specified directly as part of the `ODK_IMAGE` variable (as in `ODK_IMAGE=odkfull:v1.3.1`).
+  - A new variable `ODK_BINDS` has been introduced, allowing to specify extra bindings between a directory on the host computer and a directory inside the Docker container.
+  - Variables used by the `run.sh` script can now be set in a `src/ontology/run.sh.conf` file, which will be sourced by the wrapper script.
 
 # v1.3.1
 

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -31,6 +31,8 @@ src/ontology/target/
 src/ontology/tmp/*
 !src/ontology/tmp/README.md
 
+src/ontology/run.sh.conf
+
 src/ontology/imports/*_terms_combined.txt
 
 src/patterns/data/**/*.ofn

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -43,14 +43,17 @@ fi
 
 if [ -n "$USE_SINGULARITY" ]; then
     {% if project.use_external_date is sameas True %}export TODAY=$(date +%Y-%m-%d){% endif %}
-    singularity exec --cleanenv \
+    singularity exec --cleanenv $ODK_SINGULARITY_OPTIONS \
         --env "ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS,JAVA_OPTS=$ODK_JAVA_OPTS" \
         --bind $VOLUME_BIND \
         -W $WORK_DIR \
         docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 else
     BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /')"
-    docker run $BIND_OPTIONS -w $WORK_DIR -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
+    docker run $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
+        -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" \
+        {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %} \
+        --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 fi
 
 case "$@" in

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -14,6 +14,10 @@
 #
 # See README-editors.md for more details.
 
+if [ -f run.sh.conf ]; then
+    source run.sh.conf
+fi
+
 ODK_IMAGE=${ODK_IMAGE:-odkfull}
 TAG_IN_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $2 }')
 if [ -n "$TAG_IN_IMAGE" ]; then

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -37,6 +37,10 @@ fi
 VOLUME_BIND=$PWD/../../:/work
 WORK_DIR=/work/src/ontology
 
+if [ -n "$ODK_BINDS" ]; then
+    VOLUME_BIND="$VOLUME_BIND,$ODK_BINDS"
+fi
+
 if [ -n "$USE_SINGULARITY" ]; then
     {% if project.use_external_date is sameas True %}export TODAY=$(date +%Y-%m-%d){% endif %}
     singularity exec --cleanenv \
@@ -45,7 +49,8 @@ if [ -n "$USE_SINGULARITY" ]; then
         -W $WORK_DIR \
         docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 else
-    docker run -v $VOLUME_BIND -w $WORK_DIR -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
+    BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /')"
+    docker run $BIND_OPTIONS -w $WORK_DIR -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}--rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 fi
 
 case "$@" in


### PR DESCRIPTION
This PR:

a) Adds a new `ODK_BINDS` variable to the `run.sh` wrapper script, which can be used to specify extra volume bindings within the Docker or Singularity container. Use as follows:

```sh
ODK_BINDS=/path/to/host/dir1:/path/to/container/dir1[:options][,...] sh run.sh ...
```

b) Adds a new `ODK_DOCKER_OPTIONS` variable, to allow user to pass any custom options to the invocation of `docker run`. Another variable, `ODK_SINGULARITY_OPTIONS`, does the same for the invocation of `singularity exec`.

c) Allows to set variables for the `run.sh` wrapper in a file named `run.sh.conf` (in the same directory as the wrapper script itself). That file should contain standard Bourne-shell variable declarations, and will be sourced (if it exists) by the wrapper script. It allows to use variables such as the new `ODK_BINDS`, `ODK_DOCKER_OPTIONS`, but also the pre-existing `ODK_IMAGE` or `ODK_TAG`, once and for all in the `run.sh.conf` file, instead of having to export them to the user’s environment or set them every time the wrapper script is invoked.

closes #675 