### PR TITLE
Run commands inside the container as the current user.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -799,8 +799,10 @@ def dump_schema():
               """)
 @click.option('-v', '--verbose',      count=True)
 @click.option('-g', '--skipgit',      default=False, is_flag=True)
+@click.option('-n', '--gitname',      default=None)
+@click.option('-e', '--gitemail',     default=None)
 @click.argument('repo', nargs=-1)
-def seed(config, clean, outdir, templatedir, dependencies, title, user, source, verbose, repo, skipgit):
+def seed(config, clean, outdir, templatedir, dependencies, title, user, source, verbose, repo, skipgit, gitname, gitemail):
     """
     Seeds an ontology project
     """
@@ -879,6 +881,12 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
     for tgt in tgts:
         logging.info("  File: {}".format(tgt))
     if not skipgit:
+        if gitname is not None:
+            os.environ['GIT_AUTHOR_NAME'] = gitname
+            os.environ['GIT_COMMITTER_NAME'] = gitname
+        if gitemail is not None:
+            os.environ['GIT_AUTHOR_EMAIL'] = gitemail
+            os.environ['GIT_COMMITTER_EMAIL'] = gitemail
         runcmd("cd {dir} && git init && git add {files}".
                format(dir=outdir,
                       files=" ".join([t.replace(outdir, ".", 1) for t in tgts])))

--- a/seed-via-docker.sh
+++ b/seed-via-docker.sh
@@ -4,5 +4,7 @@ set -e
 
 ODK_IMAGE=${ODK_IMAGE:-odkfull}
 ODK_TAG=${ODK_TAG:-latest}
+ODK_GITNAME=${ODK_GITNAME:-$(git config --get user.name)}
+ODK_GITEMAIL=${ODK_GITEMAIL:-$(git config --get user.email)}
 
-docker run -v $HOME/.gitconfig:/root/.gitconfig -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE:$ODK_TAG /tools/odk.py seed "$@"
+docker run -u $(id -u):$(id -g) -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE:$ODK_TAG /tools/odk.py seed --gitname "$ODK_GITNAME" --gitemail "$ODK_GITEMAIL" "$@"

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -54,7 +54,7 @@ if [ -n "$USE_SINGULARITY" ]; then
         docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 else
     BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /')"
-    docker run $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
+    docker run -u $(id -u):$(id -g) $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
         -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" \
         {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %} \
         --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"


### PR DESCRIPTION
Make sure the command we run inside the ODK container is run under the identity of the user invoking the ODK, instead of `root`.

Running as `root` will cause any file created by the process to be owned by `root`, if the Docker daemon itself runs as a privileged user – which happens to be the case in most GNU/Linux setups.

Running as a normal user means that we can no longer bind the calling user’s own `~/.gitconfig` file to a predictable location inside the container (`/root/.gitconfig`), so instead we extract the informations we need from that file in the wrapper script and pass said informations to `odk.py` through command line arguments. The `odk.py` script will in turn pass the informations to Git using environment variables when initialising the repository.

closes #682