### PR TITLE
Add rdfxml validation

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -70,9 +70,12 @@ RUN wget -nv https://github.com/lihaoyi/Ammonite/releases/download/$AMMONITE_VER
     chmod 755 /tools/amm && \
     /tools/amm /dev/null
 
+# Install RDF/XML validation script
+COPY scripts/check-rdfxml.sh /tools/check-rdfxml
+
 # Install the ODK itself.
 COPY odk/make-release-assets.py /tools
 COPY odk/odk.py /tools
 COPY template/ /tools/templates/
-RUN chmod 755 /tools/*.py
+RUN chmod 755 /tools/*.py /tools/check-rdfxml
 CMD python3 /tools/odk.py

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -574,6 +574,12 @@ class OntologyProject(JsonSchemaMixin):
     robot_report : Dict[str, Any] = field(default_factory=lambda: ReportConfig().to_dict())
     """Block that includes settings for ROBOT report, ROBOT verify and additional reports that are generated"""
 
+    ensure_valid_rdfxml : bool = True
+    """When enabled, ensure that any RDF/XML product file is valid"""
+
+    extra_rdfxml_checks : bool = False
+    """When enabled, RDF/XML product files are checked against additional parser (currently RDFLib and Jena)"""
+
     # product groups
     import_group : Optional[ImportGroup] = None
     """Block that includes information on all ontology imports to be generated"""

--- a/requirements.txt.full
+++ b/requirements.txt.full
@@ -37,3 +37,4 @@ j2cli
 pyspellchecker
 jsonschema2md
 curies
+lightrdf

--- a/requirements.txt.lite
+++ b/requirements.txt.lite
@@ -13,3 +13,4 @@ dosdp
 tsvalid
 j2cli[yaml]
 j2cli
+lightrdf

--- a/scripts/check-rdfxml.sh
+++ b/scripts/check-rdfxml.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/bash
+
+extra_checks=0
+if [ "$1" = "--extra" ]; then
+    extra_checks=1
+    shift
+fi
+
+if [ -z "$1" ]; then
+    echo "Usage: ${0##*/} [--extra] FILE"
+    exit 10
+fi
+
+if [ ! -f "$1" ]; then
+    echo "${0##*/}: $1: file not found"
+    exit 11
+fi
+
+errors=0
+
+echo "Checking RDF/XML file $1..."
+echo -n "  LightRDF: "
+python3 <<EOF
+import sys
+from lightrdf import Parser
+parser = Parser()
+try:
+    for triple in parser.parse("$1"):
+        pass
+except Exception as e:
+    print(e)
+    sys.exit(1)
+
+print("OK")
+EOF
+test $? -eq 0 || errors=$(($errors + 1))
+
+if [ $extra_checks -eq 1 ]; then
+    echo -n "  RDFLib: "
+    if type -p rdfpipe > /dev/null ; then
+        if rdfpipe --no-out $1 ; then
+            echo "OK"
+        else
+            errors=$((errors + 1))
+        fi
+    else
+        echo "Not available"
+    fi
+
+    echo -n "  Jena: "
+    if type -p rdfparse > /dev/null ; then
+        # Jena does not return an error code, so we need to capture
+        # stderr to detect if an error occured.
+        jena_errors=$(rdfparse -s -t $1 2>&1)
+        if [ -n "$jena_errors" ]; then
+            echo "$jena_errors"
+            errors=$(($errors + 1))
+        else
+            echo "OK"
+        fi
+    else
+        echo "Not available"
+    fi
+fi
+
+exit $errors

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -219,12 +219,18 @@ RELEASE_ASSETS = \
   $(REPORT_FILES){% endif %}
 
 .PHONY: all_assets
-all_assets: $(ASSETS)
+all_assets: $(ASSETS) {% if project.ensure_valid_rdfxml %}check_rdfxml_assets{% endif %}
 
 .PHONY: show_assets
 show_assets:
 	echo $(ASSETS)
 	du -sh $(ASSETS)
+
+check_rdfxml_%: %
+	@check-rdfxml {% if project.extra_rdfxml_checks %}--extra{% endif %} $<
+
+.PHONY: check_rdfxml_assets
+check_rdfxml_assets: $(foreach product,$(MAIN_PRODUCTS),check_rdfxml_$(product).owl)
 
 # ----------------------------------------
 # Release Management


### PR DESCRIPTION
This PR adds to the standard Makefile a new `check_rdfxml_assets` target, which test each of the RDF/XML-formatted release products for correctness.

The correctness check is performed by the LightRDF Python module (which this PR adds to the odklite image). This module wraps the Rust rio_xml RDF/XML parser, which is known to be quite strict.

Two new ODK configuration options are added:

* `ensure_valid_rdfxml`: If enabled (this is the default), the `check_rdfxml_assets` target is invoked as part of the standard release workflow.
* `extra_rdfxml_checks`: If enabled (_not_ by default), then each RDF/XML release product is also checked against the RDFLib and Jena parsers (only if the ODK is running from the `odkfull` image, where those parsers are present; if running from `odklite`, that option has no effects).

closes #691
supersedes #697 