### PR TITLE
Add path constraints to the QC workflow.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,21 @@ on:
       - master
     types:
       - opened
+    paths-ignore:
+      - '**.md'
+      - 'CITATION.cff'
+      - 'LICENSE'
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'INSTALL.sh'
+      - 'env.sh'
+      - 'odk.sh'
+      - 'odk2.sh'
+      - 'seed-via-docker-131.sh'
+      - '*.bat'
+      - 'upgrade*sh'
+      - '.github/workflows/build-multiarch.yml'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Inhibit the `build-and-test` GitHub Action workflow when a PR does not modify any testable file (documentation files or helper scripts that are not part of an ODK workflow).

We list the paths that should inhibit the CI check rather than the paths that should trigger a check, so that the default action is still to trigger a check (better to trigger a check on a file we forgot to exclude than to inhibit a check on a file we forgot to include).

closes #712