### PR TITLE
Do not run Docker in interactive mode when testing programs.

### DIFF
--- a/tests/test-program.sh
+++ b/tests/test-program.sh
@@ -5,4 +5,4 @@ ODK_TAG=${ODK_TAG:-latest}
 
 program_name=$1; shift
 echo -n "Checking for $program_name... "
-docker run --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $@ >/dev/null && echo OK || echo KO
+docker run --rm obolibrary/$ODK_IMAGE:$ODK_TAG $@ >/dev/null && echo OK || echo KO


### PR DESCRIPTION
We do not need to call `docker run` in interactive mode (--interactive --tty) in `test-program.sh` when we start an ODK container just to test the programs of the ODK -- and doing so actually prevents those tests from running when `make test_odkfull_programs` is called as part of the GitHub Actions CI check, because GitHub Actions workflows run without an attached TTY. So it's better to not call Docker in interactive mode at all.