### PR TITLE
Updating actions/checkout to v3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create dummy Git user name
         run: git config --global user.name Alice
       - name: Create dummy Git user email

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up the QEMU static binaries
         uses: docker/setup-qemu-action@v1
         with:

--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -11,7 +11,7 @@ jobs:
       max-parallel: 1
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: work around permission issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build constraints.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -618,7 +618,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run ontology QC checks
         env:
@@ -644,9 +644,9 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "v1.2.32" }}{%- else %}v1.2.32{% endif %}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # Checks-out main branch under "main" directory
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: master
           path: master
@@ -661,7 +661,7 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "v1.2.32" }}{%- else %}v1.2.32{% endif %}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Classify ontology
         run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE {{ project.id }}.owl
       - name: Upload PR {{ project.id }}.owl
@@ -674,7 +674,7 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "v1.2.32" }}{%- else %}v1.2.32{% endif %}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: master
       - name: Classify ontology
@@ -692,7 +692,7 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "v1.2.32" }}{%- else %}v1.2.32{% endif %}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download master classification
         uses: actions/download-artifact@v2
         with:
@@ -714,7 +714,7 @@ jobs:
     needs: [diff_classification, edit_file]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download reasoned diff
         uses: actions/download-artifact@v2
         with:
@@ -729,7 +729,7 @@ jobs:
         with:
           file: "../../comment.md"
           identifier: "REASONED"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Download edit diff
         uses: actions/download-artifact@v2
         with:
@@ -1605,7 +1605,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master


### PR DESCRIPTION
Not 100% sure if this is needed, but github has mentioned to update node12 to node16 (https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and checkout v3 (https://github.com/actions/checkout) in whats new says run node16 by default, so figured its a good idea to do this update.

Not sure if we need testing etc. and not sure how to do that