### PR TITLE
fix wrong target-rule for recreating components in comment/help section

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1042,7 +1042,7 @@ Core commands:
 {% if project.import_group is defined %}
 Imports management:
 * refresh-imports:			Refresh all imports and mirrors.
-* refresh-components:			Refresh all components.
+* recreate-components:			Recreate all components.
 * no-mirror-refresh-imports:		Refresh all imports without downloading mirrors.
 * refresh-imports-excluding-large:	Refresh all imports and mirrors, but skipping the ones labelled as 'is_large'.
 * refresh-%:				Refresh a single import, i.e. refresh-go will refresh 'imports/go_import.owl'.


### PR DESCRIPTION
This PR fixes the wrong target-rule for recreating components in the comment/help section at the end of the Makefile, which previously stated `refresh-components` whereas the actual target-rule is called `recreate-components` (see [line 458](https://github.com/INCATools/ontology-development-kit/blob/master/template/src/ontology/Makefile.jinja2#L458))


