### PR TITLE
Add optional date check

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -329,7 +329,7 @@ class ReportConfig(JsonSchemaMixin):
     
     custom_sparql_checks : Optional[List[str]] = field(default_factory=lambda: ['owldef-self-reference', 'iri-range', 'label-with-iri', 'multiple-replaced_by'])
     """ Chose which additional sparql checks you want to run. The related sparql query must be named CHECKNAME-violation.sparql, and be placed in the src/sparql directory.
-        The custom sparql checks available are: 'owldef-self-reference', 'redundant-subClassOf', 'taxon-range', 'iri-range', 'iri-range-advanced', 'label-with-iri', 'multiple-replaced_by'.
+        The custom sparql checks available are: 'owldef-self-reference', 'redundant-subClassOf', 'taxon-range', 'iri-range', 'iri-range-advanced', 'label-with-iri', 'multiple-replaced_by', 'term-tracker-uri', 'illegal-date'.
     """
 
     custom_sparql_exports : Optional[List[str]] = field(default_factory=lambda: ['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms'])

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -537,6 +537,19 @@ SELECT ?term ?term_tracker ?term_tracker_type WHERE {
 }
 {% endif %}
 
+{%- if project.robot_report.custom_sparql_checks is not defined or 'illegal-date' in project.robot_report.custom_sparql_checks %}
+^^^ src/sparql/illegal-date-violation.sparql
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT DISTINCT ?term ?property ?value WHERE
+{
+  VALUES ?property {dct:date dct:issued dct:created}
+  ?term ?property ?value .
+  FILTER (datatype(?value) != xsd:date || !regex(str(?value), '^\\d{4}-\\d\\d-\\d\\d$'))
+}
+{% endif %}
+
 {%- if project.components is defined %}
 {%- for component in project.components.products %}
 ^^^ src/ontology/components/{{ component.filename }}


### PR DESCRIPTION
This PR adds a sparql query that can be added as an optional QC that only allows dates in a certain format (xsd:date, XXXX-XX-XX) 
Fixes https://github.com/INCATools/ontology-development-kit/issues/587
Proof of Concept: https://github.com/obophenotype/uberon/pull/2706