### PR TITLE
Add make command sequence for a local cronjob for dev image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,3 +174,9 @@ constraints.txt: requirements.txt.full
 
 clean-tests:
 	rm -rf target/*
+
+dev-cronjob:
+	git pull
+	docker buildx rm multiarch
+	docker buildx create --name multiarch --driver docker-container --use
+	$(MAKE) tests publish-multiarch-dev

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ constraints.txt: requirements.txt.full
 clean-tests:
 	rm -rf target/*
 
-dev-cronjob:
+dev-test-publish:
 	git pull
 	docker buildx rm multiarch
 	docker buildx create --name multiarch --driver docker-container --use


### PR DESCRIPTION
This is basically the sequence of commands I need to run every time I want to publish a dev image. Now, I want to simply set up a cronjob on my server that does this for me.

The idea is to simply run:

```
make dev-cronjob
```

every Sunday.. I am not sure whether this is a great idea, or whether this way of doing it is right.. What do you think @gouttegd?