### PR TITLE
Pass a GitHub token to the container

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -73,6 +73,9 @@ RUN wget -nv https://github.com/lihaoyi/Ammonite/releases/download/$AMMONITE_VER
 # Install RDF/XML validation script
 COPY scripts/check-rdfxml.sh /tools/check-rdfxml
 
+# Force Git to accept working on a repository owned by someone else
+RUN echo "[safe]\n    directory = /work" >> /etc/gitconfig
+
 # Install the ODK itself.
 COPY odk/make-release-assets.py /tools
 COPY odk/odk.py /tools

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -7,7 +7,7 @@ bin/
 *.tmp.owl
 *.tmp.json
 
-.github/token
+.github/token.txt
 
 src/ontology/mirror
 src/ontology/mirror/*

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -7,6 +7,8 @@ bin/
 *.tmp.owl
 *.tmp.json
 
+.github/token
+
 src/ontology/mirror
 src/ontology/mirror/*
 src/ontology/reports/*

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -32,6 +32,7 @@ src/ontology/tmp/*
 !src/ontology/tmp/README.md
 
 src/ontology/run.sh.conf
+src/ontology/run.sh.env
 
 src/ontology/imports/*_terms_combined.txt
 

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -21,8 +21,8 @@ fi
 # Look for a GitHub token
 if [ -n "$GH_TOKEN" ]; then
     :
-elif [ -f ../../.github/token ]; then
-    GH_TOKEN=$(cat ../../.github/token)
+elif [ -f ../../.github/token.txt ]; then
+    GH_TOKEN=$(cat ../../.github/token.txt)
 elif [ -f $XDG_CONFIG_HOME/ontology-development-kit/github/token ]; then
     GH_TOKEN=$(cat $XDG_CONFIG_HOME/ontology-development-kit/github/token)
 elif [ -f "$HOME/Library/Application Support/ontology-development-kit/github/token" ]; then

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -18,6 +18,17 @@ if [ -f run.sh.conf ]; then
     source run.sh.conf
 fi
 
+# Look for a GitHub token
+if [ -n "$GH_TOKEN" ]; then
+    :
+elif [ -f ../../.github/token ]; then
+    GH_TOKEN=$(cat ../../.github/token)
+elif [ -f $XDG_CONFIG_HOME/ontology-development-kit/github/token ]; then
+    GH_TOKEN=$(cat $XDG_CONFIG_HOME/ontology-development-kit/github/token)
+elif [ -f "$HOME/Library/Application Support/ontology-development-kit/github/token" ]; then
+    GH_TOKEN=$(cat "$HOME/Library/Application Support/ontology-development-kit/github/token")
+fi
+
 ODK_IMAGE=${ODK_IMAGE:-odkfull}
 TAG_IN_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $2 }')
 if [ -n "$TAG_IN_IMAGE" ]; then
@@ -49,6 +60,7 @@ fi
 cat <<EOF > run.sh.env
 ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS
 JAVA_OPTS=$ODK_JAVA_OPTS
+GH_TOKEN=$GH_TOKEN
 EOF
 
 if [ -n "$USE_SINGULARITY" ]; then

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -45,20 +45,28 @@ if [ -n "$ODK_BINDS" ]; then
     VOLUME_BIND="$VOLUME_BIND,$ODK_BINDS"
 fi
 
+# Gather environment variables into a single file
+cat <<EOF > run.sh.env
+ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS
+JAVA_OPTS=$ODK_JAVA_OPTS
+EOF
+
 if [ -n "$USE_SINGULARITY" ]; then
     {% if project.use_external_date is sameas True %}export TODAY=$(date +%Y-%m-%d){% endif %}
     singularity exec --cleanenv $ODK_SINGULARITY_OPTIONS \
-        --env "ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS,JAVA_OPTS=$ODK_JAVA_OPTS" \
+        --env-file run.sh.env \
         --bind $VOLUME_BIND \
         -W $WORK_DIR \
         docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 else
     BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /')"
     docker run -u $(id -u):$(id -g) $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
-        -e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" \
+        --env-file run.sh.env \
         {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %} \
         --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 fi
+
+rm run.sh.env
 
 case "$@" in
 *update_repo*|*release*)

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -78,7 +78,7 @@ else
         --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 fi
 
-rm run.sh.env
+rm -f run.sh.env
 
 case "$@" in
 *update_repo*|*release*)


### PR DESCRIPTION
This PR updates the `run.sh` file to try to obtain a GitHub token (either from the environment, or from a few selected locations) and pass it as a `GH_TOKEN` environment variable inside the container.

This allows to use GitHub clients such as `gh` from within the container.

closes #599 