### PR TITLE
Disable the LightRDF-based RDF/XML validation check.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -576,11 +576,8 @@ class OntologyProject(JsonSchemaMixin):
     robot_report : Dict[str, Any] = field(default_factory=lambda: ReportConfig().to_dict())
     """Block that includes settings for ROBOT report, ROBOT verify and additional reports that are generated"""
 
-    ensure_valid_rdfxml : bool = True
+    ensure_valid_rdfxml : bool = False
     """When enabled, ensure that any RDF/XML product file is valid"""
-
-    extra_rdfxml_checks : bool = False
-    """When enabled, RDF/XML product files are checked against additional parser (currently RDFLib and Jena)"""
 
     # product groups
     import_group : Optional[ImportGroup] = None

--- a/scripts/check-rdfxml.sh
+++ b/scripts/check-rdfxml.sh
@@ -1,31 +1,71 @@
 #!/usr/bin/bash
 
-extra_checks=0
-if [ "$1" = "--extra" ]; then
-    extra_checks=1
-    shift
-fi
+check_lightrdf=0
+check_rdflib=1
+check_jena=1
+rdfxml_file=
 
-if [ -z "$1" ]; then
-    echo "Usage: ${0##*/} [--extra] FILE"
+while [ -n "$1" ]; do
+    case "$1" in
+    --lightrdf)
+        check_lightrdf=1
+        shift
+        ;;
+
+    --no-lightrdf)
+        check_lightrdf=0
+        shift
+        ;;
+
+    --rdflib)
+        check_rdflib=1
+        shift
+        ;;
+
+    --no-rdflib)
+        check_rdflib=0
+        shift
+        ;;
+
+    --jena)
+        check_jena=1
+        shift
+        ;;
+
+    --no-jena)
+        check_jena=0
+        shift
+        ;;
+
+    *)
+        rdfxml_file=$1
+        shift
+        ;;
+    esac
+done
+
+if [ -z "$rdfxml_file" ]; then
+    echo "Usage: ${0##*/} [[--no-]lightrdf] [[--no-]rdflib] [[--no-]jena] FILE"
     exit 10
 fi
 
-if [ ! -f "$1" ]; then
-    echo "${0##*/}: $1: file not found"
+if [ ! -f "$rdfxml_file" ]; then
+    echo "${0##*/}: $rdfxml_file: file not found"
     exit 11
 fi
 
 errors=0
 
-echo "Checking RDF/XML file $1..."
-echo -n "  LightRDF: "
-python3 <<EOF
+echo "Checking RDF/XML file $rdfxml_file..."
+
+if [ $check_lightrdf -eq 1 ]; then
+    echo -n "  LightRDF: "
+    python3 <<EOF
 import sys
 from lightrdf import Parser
 parser = Parser()
 try:
-    for triple in parser.parse("$1"):
+    for triple in parser.parse("$rdfxml_file"):
         pass
 except Exception as e:
     print(e)
@@ -33,12 +73,13 @@ except Exception as e:
 
 print("OK")
 EOF
-test $? -eq 0 || errors=$(($errors + 1))
+    test $? -eq 0 || errors=$(($errors + 1))
+fi
 
-if [ $extra_checks -eq 1 ]; then
+if [ $check_rdflib -eq 1 ]; then
     echo -n "  RDFLib: "
     if type -p rdfpipe > /dev/null ; then
-        if rdfpipe --no-out $1 ; then
+        if rdfpipe --no-out $rdfxml_file ; then
             echo "OK"
         else
             errors=$((errors + 1))
@@ -46,17 +87,15 @@ if [ $extra_checks -eq 1 ]; then
     else
         echo "Not available"
     fi
+fi
 
+if [ $check_jena -eq 1 ]; then
     echo -n "  Jena: "
-    if type -p rdfparse > /dev/null ; then
-        # Jena does not return an error code, so we need to capture
-        # stderr to detect if an error occured.
-        jena_errors=$(rdfparse -s -t $1 2>&1)
-        if [ -n "$jena_errors" ]; then
-            echo "$jena_errors"
-            errors=$(($errors + 1))
-        else
+    if type -p riot > /dev/null ; then
+        if riot --validate $rdfxml_file ; then
             echo "OK"
+        else
+            errors=$((errors + 1))
         fi
     else
         echo "Not available"

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -227,7 +227,7 @@ show_assets:
 	du -sh $(ASSETS)
 
 check_rdfxml_%: %
-	@check-rdfxml {% if project.extra_rdfxml_checks %}--extra{% endif %} $<
+	@check-rdfxml $<
 
 .PHONY: check_rdfxml_assets
 check_rdfxml_assets: $(foreach product,$(MAIN_PRODUCTS),check_rdfxml_$(product).owl)


### PR DESCRIPTION
We cannot rely on LightRDF to not incorrectly flag correct RDF/XML files as being unparseable, so we disable the LightRDF-based check by defult.

We remove the `extra_rdfxml_checks` ODK configuration parameter (which has never been in a public release of the ODK anyway). We only keep the `ensure_valid_rdfxml` parameter instead, which is now OFF by default (as it triggers the Jena-based and RDFLib-based checks, which are time-consuming).

The `check_rdfxml` script now accept `--lightrdf`, `--rdflib`, and `--jena` options to enable the respective checks, with RDFLib and Jena being enabled by default (but the script itself is only called as part of the standard workflow if the `ensure_valid_rdfxml` ODK parameter is ON). This will allow for easy changing of the validators to used by default in the future (including re-enabling the LightRDF validator, if/when it is fixed).

related to #743