### PR TITLE
Make sure run.sh.env is always deleted.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -57,6 +57,9 @@ if [ -n "$ODK_BINDS" ]; then
 fi
 
 # Gather environment variables into a single file
+# (and make sure that file is deleted no matter what)
+trap "rm -f run.sh.env" EXIT
+trap "rm -f run.sh.env; trap - INT; kill -INT $$" INT
 cat <<EOF > run.sh.env
 ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS
 JAVA_OPTS=$ODK_JAVA_OPTS
@@ -77,8 +80,6 @@ else
         {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %} \
         --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 fi
-
-rm -f run.sh.env
 
 case "$@" in
 *update_repo*|*release*)


### PR DESCRIPTION
To prevent people from inadvertently committing the run.sh.env file, we make sure it is always deleted when the run.sh script terminates. We do that by deleting the file in a EXIT trap, which is systematically executed when the script terminates for any reason.

Not all shells execute the EXIT trap when the script termimates upon being interrupted by a signal though, as this is not a POSIX-mandated behaviour (Bash, Dash, and seemingly Zsh do so). For stricter POSIX-compliant shells, we also trap the SIGINT signal, so that the cleanup call will be executed if the user stops a long-running invocation with Ctrl-C.