### PR TITLE
Use UID/GID of the calling user inside the container

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && \
         curl \
         jq \
         rsync \
-        time
+        time \
+        sudo
 
 # Install Python environment (copied over from the builder image).
 COPY --from=obolibrary/odkbuild:latest /staging/lite /

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -79,7 +79,8 @@ RUN echo "[safe]\n    directory = /work" >> /etc/gitconfig
 
 # Make sure we run under an existing user account with UID/GID
 # matching the UID/GID of the calling user
-COPY --chmod=755 scripts/entrypoint.sh /usr/local/sbin/odkuser-entrypoint.sh
+COPY scripts/entrypoint.sh /usr/local/sbin/odkuser-entrypoint.sh
+RUN chmod 755 /usr/local/sbin/odkuser-entrypoint.sh
 ENTRYPOINT ["/usr/local/sbin/odkuser-entrypoint.sh"]
 # secure_path is enabled by default in Debian/Ubuntu, disable it
 RUN sed -i '/secure_path/d' /etc/sudoers

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -77,6 +77,13 @@ COPY scripts/check-rdfxml.sh /tools/check-rdfxml
 # Force Git to accept working on a repository owned by someone else
 RUN echo "[safe]\n    directory = /work" >> /etc/gitconfig
 
+# Make sure we run under an existing user account with UID/GID
+# matching the UID/GID of the calling user
+COPY --chmod=755 scripts/entrypoint.sh /usr/local/sbin/odkuser-entrypoint.sh
+ENTRYPOINT ["/usr/local/sbin/odkuser-entrypoint.sh"]
+# secure_path is enabled by default in Debian/Ubuntu, disable it
+RUN sed -i '/secure_path/d' /etc/sudoers
+
 # Install the ODK itself.
 COPY odk/make-release-assets.py /tools
 COPY odk/odk.py /tools

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+REAL_USER_ID=${ODKUSER_USER_ID:-1000}
+REAL_GROUP_ID=${ODKUSER_GROUP_ID:-1000}
+
+groupadd -o -g $REAL_GROUP_ID odkuser
+useradd -o -s /bin/bash -u $REAL_USER_ID -g $REAL_GROUP_ID -c "ODK User" -m odkuser
+PATH=$PATH:/home/odkuser/.local/bin
+
+exec sudo -H -E -u odkuser "$@"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,5 +6,7 @@ REAL_GROUP_ID=${ODKUSER_GROUP_ID:-1000}
 groupadd -o -g $REAL_GROUP_ID odkuser
 useradd -o -s /bin/bash -u $REAL_USER_ID -g $REAL_GROUP_ID -c "ODK User" -m odkuser
 PATH=$PATH:/home/odkuser/.local/bin
+[ -d /work ] || mkdir /work
+chown -R odkuser:odkuser /work
 
 exec sudo -H -E -u odkuser "$@"

--- a/seed-via-docker.sh
+++ b/seed-via-docker.sh
@@ -9,4 +9,4 @@ ODK_TAG=${ODK_TAG:-latest}
 ODK_GITNAME=${ODK_GITNAME:-$(git config --get user.name)}
 ODK_GITEMAIL=${ODK_GITEMAIL:-$(git config --get user.email)}
 
-docker run -u $(id -u):$(id -g) -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE:$ODK_TAG /tools/odk.py seed --gitname "$ODK_GITNAME" --gitemail "$ODK_GITEMAIL" "$@"
+docker run -e ODKUSER_USER_ID=$(id -u) -e ODKUSER_GROUP_ID=$(id -g) -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE:$ODK_TAG /tools/odk.py seed --gitname "$ODK_GITNAME" --gitemail "$ODK_GITEMAIL" "$@"

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -64,6 +64,8 @@ cat <<EOF > run.sh.env
 ROBOT_JAVA_ARGS=$ODK_JAVA_OPTS
 JAVA_OPTS=$ODK_JAVA_OPTS
 GH_TOKEN=$GH_TOKEN
+ODKUSER_USER_ID=$(id -u)
+ODKUSER_GROUP_ID=$(id -g)
 EOF
 
 if [ -n "$USE_SINGULARITY" ]; then
@@ -75,7 +77,7 @@ if [ -n "$USE_SINGULARITY" ]; then
         docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 else
     BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /')"
-    docker run -u $(id -u):$(id -g) $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
+    docker run $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
         --env-file run.sh.env \
         {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %} \
         --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"


### PR DESCRIPTION
This PR is another attempt at fixing #682.

Instead of calling `docker run` with `-u $(id -u):$(id -g)` (which does the job but introduces various side-effects, mostly related to the fact that the user ID that is used has no home directory and no entry in `/etc/passwd`), we use an [entrypoint script](https://docs.docker.com/engine/reference/builder/#entrypoint) that will be executed when we “enter” the container. That script creates a dedicated `odkuser` account, which is given the UID and GID of the calling user (passed in the `run.sh` script as new environment variables). The entrypoint script then executes the command to run with the privileges of the newly created user account.

This allows to simultaneously ensure:
* that the command we run inside the container runs with the privileges of the user who invoked the `run.sh` script, thereby ensuring that any files created by that command have correct ownership;
* that the user account used to run the command does have a home directory (`/home/odkuser`) and a `/etc/passwd` entry.

The latter point will allow to run commands such as `pip install` to install supplementary Python packages in the `odkuser` user’s home directory.

As for the previous attempt to fix that problem (#684), a consequence of that PR is that running commands that require _root_ privileges inside the container (such as `apt-get install` to install supplementary packages not part of the image) will no longer be possible. If people really need that we can add a ODK-level option like `run_as_root` or similar.