### PR TITLE
Avoid using `source` in run.sh.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -15,7 +15,7 @@
 # See README-editors.md for more details.
 
 if [ -f run.sh.conf ]; then
-    source ./run.sh.conf
+    . ./run.sh.conf
 fi
 
 # Look for a GitHub token


### PR DESCRIPTION
The `source` shell built-in is not specified by POSIX and may not be supported by all shells. The dash(1) shell at least, when started as `/bin/sh`, does not recognize it. So we use instead the `.` command, which should be supported by any POSIX-compliant shell (https://pubs.opengroup.org/onlinepubs/009695299/utilities/dot.html).