### PR TITLE
Use a pre-built Konclude binary on arm64.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,9 @@ RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends 
 COPY --from=obolibrary/odkbuild:latest /staging/full /
 
 # Install Konclude.
-# On x86_64, we get it from a pre-built release; on arm64, we
-# have built it in the builder image, now we need to install
-# the run-time dependencies (Qt5).
+# On x86_64, we get it from a pre-built release from upstream; on arm64,
+# we use a custom pre-built binary to which we just need to add the
+# run-time dependencies (the binary is not statically linked).
 ARG TARGETARCH
 RUN test "x$TARGETARCH" = xamd64 && ( \
         wget -nv https://github.com/konclude/Konclude/releases/download/v0.7.0-1138/Konclude-v0.7.0-1138-Linux-x64-GCC-Static-Qt5.12.10.zip \
@@ -64,7 +64,13 @@ RUN test "x$TARGETARCH" = xamd64 && ( \
         rm Konclude.zip \
     ) || ( \
         DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
-            libqt5xml5 libqt5network5 libqt5concurrent5 \
+            libqt5xml5 libqt5network5 libqt5concurrent5 && \
+        wget -nv https://incenp.org/files/softs/konclude/0.7/Konclude-v0.7.0-1138-Linux-arm64-GCC.zip \
+            -O /tools/Konclude.zip && \
+        unzip Konclude.zip && \
+        mv Konclude-v0.7.0-1138-Linux-arm64-GCC/Binaries/Konclude /tools/Konclude && \
+        rm -rf Konclude-v0.7.0-1138-Linux-arm64-GCC && \
+        rm Konclude.zip \
     )
 
 # Install Jena.

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -96,21 +96,3 @@ RUN wget -nv https://github.com/ontodev/rdftab.rs/archive/refs/tags/v$RDFTAB_VER
     install -D -m 755 target/release/rdftab /staging/full/usr/bin/rdftab && \
     cd /build && \
     rm -rf rdftab.rs-$RDFTAB_VERSION rdftab.tar.gz /root/.cargo
-
-# Compile Konclude if we are not on x86_64
-# (building Konclude is time-consuming, so we avoid it
-#  on x86_64 where a pre-compiled binary is available).
-ARG TARGETARCH
-RUN test "x$TARGETARCH" != xamd64 && (apt-get update && \
-        DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
-            qtbase5-dev qt5-qmake qtbase5-dev-tools wget && \
-        wget -nv https://github.com/konclude/Konclude/archive/refs/tags/v0.7.0-1138.tar.gz \
-            -O /build/Konclude-0.7.0.tar.gz && \
-        tar xf Konclude-0.7.0.tar.gz && \
-        cd Konclude-0.7.0-1138 && \
-        qmake -r CONFIG+=release CONFIG-=debug CONFIG+=static QT-=gui KoncludeWithoutRedland.pro && \
-        make && \
-        install -D -m 755 Release/Konclude /staging/full/usr/bin/Konclude && \
-        cd /build && \
-        rm -rf Konclude-0.7.0-1138 Konclude-0.7.0.tar.gz \
-    ) || true


### PR DESCRIPTION
When building odkfull for x86_64, we use a binary version of Konclude provided directly by upstream. But when building for arm64, there is no binary available and we have to build Konclude from source (we do that in the odkbuild image).

Building Konclude from source is time-consuming (up to several hours), and doing that every time one builds a ODK image is a waste since Konclude has not changed since its last release in 2021.

This PR therefore updates the arm64 build to use a custom build of Konclude that has only been built once and for all by myself. This considerably speeds up the build for arm64.