### PR TITLE
Allow passing configuration options to the OWL API.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -40,6 +40,14 @@ ODK_TAG=${ODK_TAG:-latest}
 ODK_JAVA_OPTS={% if project.robot_java_args is defined and project.robot_java_args|length %}${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}{% else %}${ODK_JAVA_OPTS:--Xmx8G}{% endif %}
 ODK_DEBUG=${ODK_DEBUG:-no}
 
+# Convert OWLAPI_* environment variables to the OWLAPI as Java options
+# See http://owlcs.github.io/owlapi/apidocs_4/org/semanticweb/owlapi/model/parameters/ConfigurationOptions.html
+# for a list of allowed options
+OWLAPI_OPTIONS_NAMESPACE=org.semanticweb.owlapi.model.parameters.ConfigurationOptions
+for owlapi_var in $(env | sed -n s/^OWLAPI_//p) ; do
+    ODK_JAVA_OPTS="$ODK_JAVA_OPTS -D$OWLAPI_OPTIONS_NAMESPACE.${owlapi_var%=*}=${owlapi_var#*=}"
+done
+
 TIMECMD=
 if [ x$ODK_DEBUG = xyes ]; then
     # If you wish to change the format string, take care of using


### PR DESCRIPTION
Update the run.sh script to check for environment variables with a name starting with `OWLAPI_`. All such variables are converted to OWLAPI Java options appended to the `ODK_JAVA_OPTS` variable, which is passed to the container.

For example, an environment variable `OWLAPI_INDENT_SIZE=2` will be converted to
`-Dorg.semanticweb.owlapi.model.parameters.ConfigurationOptions.INDENT_SIZE=2`.

No validation of the option is performed; it is up to the user to ensure that the name after OWLAPI_ corresponds to a valid OWLAPI configuration parameter.

closes #778