### PR TITLE
Do not set UID/GID in seed-via-docker.sh.

### DIFF
--- a/seed-via-docker.sh
+++ b/seed-via-docker.sh
@@ -9,4 +9,4 @@ ODK_TAG=${ODK_TAG:-latest}
 ODK_GITNAME=${ODK_GITNAME:-$(git config --get user.name)}
 ODK_GITEMAIL=${ODK_GITEMAIL:-$(git config --get user.email)}
 
-docker run -u $(id -u):$(id -g) -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE:$ODK_TAG /tools/odk.py seed --gitname "$ODK_GITNAME" --gitemail "$ODK_GITEMAIL" "$@"
+docker run -v $PWD:/work -w /work --rm obolibrary/$ODK_IMAGE:$ODK_TAG /tools/odk.py seed --gitname "$ODK_GITNAME" --gitemail "$ODK_GITEMAIL" "$@"


### PR DESCRIPTION
PR #771 partially reverted a temporarily introduced change in the run.sh script (the use of docker's -u option), but it did not revert a similar change in seed-via-docker.sh. As a result, the test suite was still run under the identity of a non-root user, which caused at least one test to fail (the sssom test, because the sssom tool uses the bioregistry module, which caches some data in the home directory).