### PR TITLE
Do not create individual import modules when use_base_merging is enabled

### DIFF
--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -23,9 +23,13 @@
 {% if project.edit_format == "obo" %}
 format-version: 1.2
 {% if project.import_group is defined -%}
+{% if project.import_group.use_base_merging %}
+import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/merged_import.owl
+{% else %}
 {% for imp in project.import_group.products %}
 import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{ imp.id }}_import.owl
 {% endfor %}
+{% endif %}
 {% endif %}
 {%- if project.use_dosdps %}
 import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/patterns/definitions.owl
@@ -70,9 +74,13 @@ Prefix(dcterms:=<http://purl.org/dc/terms/>)
 
 Ontology(<{{ project.uribase }}/{{ project.id }}.owl>
 {% if project.import_group is defined -%}
+{% if project.import_group.use_base_merging %}
+Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/merged_import.owl>)
+{% else %}
 {% for imp in project.import_group.products %}
 Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{ imp.id }}_import.owl>)
 {% endfor %}
+{% endif %}
 {% endif %}
 
 {%- if project.use_dosdps %}
@@ -180,6 +188,28 @@ imports/%_import.owl: mirror/%.owl
 	echo "ERROR: You have configured your default module type to be custom; this behavior needs to be overwritten in {{ project.id }}.Makefile!" && touch $@
 {% endif %}
 {%- endif %}
+{% if project.import_group.use_base_merging %}
+{#-
+
+  Single merged import file
+
+#}
+^^^ src/ontology/imports/merged-import.owl
+<?xml version="1.0"?>
+<rdf:RDF 
+     xml:base="{{ project.uribase }}/"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:obo="http://purl.obolibrary.org/obo/">
+    <owl:Ontology rdf:about="{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/merged_import.owl"/>
+
+    <!-- This is a placeholder, it will be regenerated when makefile is first executed -->
+</rdf:RDF>
+{% else %}
 {#-
 
   Imports files, one per import
@@ -201,6 +231,8 @@ imports/%_import.owl: mirror/%.owl
 
     <!-- This is a placeholder, it will be regenerated when makefile is first executed -->
 </rdf:RDF>
+{% endfor %}
+{% endif %}
 {#-
 
   Import Term files
@@ -212,6 +244,7 @@ imports/%_import.owl: mirror/%.owl
   TODO: Decide if we should either query ontobee for seed terms OR have the seed list provided in the project.yaml
 
 #}
+{% for imp in project.import_group.products %}
 ^^^ src/ontology/imports/{{ imp.id }}_terms.txt
 {% endfor %}
 {#-

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -194,7 +194,7 @@ imports/%_import.owl: mirror/%.owl
   Single merged import file
 
 #}
-^^^ src/ontology/imports/merged-import.owl
+^^^ src/ontology/imports/merged_import.owl
 <?xml version="1.0"?>
 <rdf:RDF 
      xml:base="{{ project.uribase }}/"

--- a/template/src/ontology/catalog-v001.xml.jinja2
+++ b/template/src/ontology/catalog-v001.xml.jinja2
@@ -3,8 +3,8 @@
 <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public" xml:base="">
 {% if project.import_group is defined %}
   {% if project.import_group.use_base_merging %}
-  <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{imp.id}}_import.owl" uri="imports/merged_import.owl"/>
-  <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{imp.id}}_import.owl" uri="imports/merged_import.obo"/>
+  <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/merged_import.owl" uri="imports/merged_import.owl"/>
+  <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/merged_import.obo" uri="imports/merged_import.obo"/>
   {% else %}
   {% for imp in project.import_group.products %}
   <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{imp.id}}_import.owl" uri="imports/{{imp.id}}_import.owl"/>

--- a/template/src/ontology/catalog-v001.xml.jinja2
+++ b/template/src/ontology/catalog-v001.xml.jinja2
@@ -2,10 +2,15 @@
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
 <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public" xml:base="">
 {% if project.import_group is defined %}
+  {% if project.import_group.use_base_merging %}
+  <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{imp.id}}_import.owl" uri="imports/merged_import.owl"/>
+  <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{imp.id}}_import.owl" uri="imports/merged_import.obo"/>
+  {% else %}
   {% for imp in project.import_group.products %}
   <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{imp.id}}_import.owl" uri="imports/{{imp.id}}_import.owl"/>
   <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{imp.id}}_import.obo" uri="imports/{{imp.id}}_import.obo"/>
   {% endfor %}
+  {% endif %}
 {% endif %}
 {% if project.components is defined %}
   {% for component in project.components.products %}


### PR DESCRIPTION
When `use_base_merging` is enabled, the seeding process should only create a single `merged_import.owl` module, instead of one import module for each declared import.

Likewise, the auto-generated -edit file should contain a single import instruction for the single merged module.

closes #828