### PR TITLE
Added table-reader plugin for mkvdocs

### DIFF
--- a/requirements.txt.full
+++ b/requirements.txt.full
@@ -26,6 +26,7 @@ ontodev-cogs
 ontodev-gizmos
 mkdocs
 mkdocs-material
+mkdocs-table-reader-plugin
 funowl
 kgx
 linkml

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -1730,6 +1730,7 @@ theme:
     - content.tabs.link
 plugins:
   - search
+  - table-reader
 markdown_extensions:
   - pymdownx.highlight:
   - pymdownx.inlinehilite


### PR DESCRIPTION
Adding table-reader-plugin for mkvdocs. This allows to generate markdown table from tsv or csv files.

- Example for csv: `{{ read_csv('tables/basic_table.csv') }}`
- Example for tsv: `{{ read_table('tables/basic_table.tsv') }}` Default separator is \t

More info [here](https://timvink.github.io/mkdocs-table-reader-plugin/)
