### PR TITLE
Fix build on M1 architecture.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ EMAIL_ARGS=
 
 CACHE=
 
-ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
+ARCH=linux/$(shell uname -m | sed 's/x86_64/amd64/')
 PLATFORMS=linux/amd64,linux/arm64
 
 .PHONY: .FORCE

--- a/docker/builder/Makefile
+++ b/docker/builder/Makefile
@@ -1,6 +1,6 @@
 CACHE=
 
-ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
+ARCH=linux/$(shell uname -m | sed 's/x86_64/amd64/')
 PLATFORMS=linux/amd64,linux/arm64
 
 build:

--- a/docker/odklite/Makefile
+++ b/docker/odklite/Makefile
@@ -6,7 +6,7 @@ TAGS_OPTION=-t $(IM):$(VERSION) -t $(IM):latest
 
 CACHE=
 
-ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
+ARCH=linux/$(shell uname -m | sed 's/x86_64/amd64/')
 PLATFORMS=linux/amd64,linux/arm64
 
 build:

--- a/docker/robot/Makefile
+++ b/docker/robot/Makefile
@@ -5,7 +5,7 @@ IM=obolibrary/robot
 
 CACHE=
 
-ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
+ARCH=linux/$(shell uname -m | sed 's/x86_64/amd64/')
 PLATFORMS=linux/amd64,linux/arm64
 
 build:


### PR DESCRIPTION
It seems that in recent versions of Docker, the `--platform` option of `docker build` no longer accepts a single architecture name as its argument (as in `--platform arm64`). Instead, a tuple specifying both the operating system and the architecture (e.g. `linux/arm64`) should be used.

Using `--platform arm64` now causes Docker to fail building the ODK on arm64 Apple machines because it can’t find the arm64 variant of Ubuntu (our base image) anymore.

So this PR updates all the Makefiles to make sure they only use the new `os/arch` syntax.