### PR TITLE
Automatically check whether the repository needs to be updated

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -22,6 +22,7 @@ import subprocess
 import shutil
 from shutil import copy, copymode
 import logging
+from hashlib import sha256
 
 logging.basicConfig(level=logging.INFO)
 TEMPLATE_SUFFIX = '.jinja2'
@@ -704,15 +705,22 @@ class Generator(object):
 
         Optionally injects additional values
         """
+        config_hash = None
         if config_file is None:
             project = OntologyProject()
         else:
             with open(config_file, 'r') as stream:
+                h = sha256()
+                h.update(stream.read().encode())
+                config_hash = h.hexdigest()
+                stream.seek(0)
                 try:
                     obj = yaml.load(stream, Loader=yaml.FullLoader)
                 except yaml.YAMLError as exc:
                     print(exc)
             project = from_dict(data_class=OntologyProject, data=obj)
+        if config_hash:
+            project.config_hash = config_hash
         if title:
             project.title = title
         if org:

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -17,6 +17,11 @@
 
 {{ project.custom_makefile_header }}
 
+{%- if project.config_hash %}
+# Fingerprint of the configuration file when this Makefile was last generated
+CONFIG_HASH=                {{ project.config_hash }}
+{% endif %}
+
 # ----------------------------------------
 # Standard Constants
 # ----------------------------------------
@@ -96,7 +101,7 @@ RELEASE_ARTEFACTS = $(sort {% for release in project.release_artefacts %}{% if r
 all: all_odk
 
 .PHONY: all_odk
-all_odk: odkversion test all_assets{% if project.release_diff %} release_diff{% endif %}
+all_odk: odkversion{% if project.config_hash %} config_check{% endif %} test all_assets{% if project.release_diff %} release_diff{% endif %}
 
 .PHONY: test
 test: odkversion {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot_report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
@@ -119,6 +124,14 @@ odkversion:
 	echo "ODK Makefile version: $(ODK_VERSION_MAKEFILE) (this is the version of the ODK with which this Makefile was generated, \
         not the version of the ODK you are running)" &&\
 	echo "ROBOT version (ODK): " && $(ROBOT) --version
+
+{%- if project.config_hash %}
+.PHONY: config_check
+config_check:
+	@if [ "$$(sha256sum $(ONT)-odk.yaml | cut -c1-64)" = "$(CONFIG_HASH)" ]; then \
+		echo "Repository is up-to-date." ; else \
+		echo "Your ODK configuration has changed since this Makefile was generated. You may need to run 'make update_repo'." ; fi
+{% endif %}
 
 $(TMPDIR) $(REPORTDIR) $(MIRRORDIR) $(IMPORTDIR) $(COMPONENTSDIR) $(SUBSETDIR):
 	mkdir -p $@


### PR DESCRIPTION
This PR implements the behaviour suggested in #856.

That is, when a repository is initialised or updated, the ODK configuration file is hashed and the hash value is baked in the generated Makefile. A new `config_check` rule (called as a dependency to the `all_odk` rule) then compares the stored hash with a freshly computed hash on the current configuration file, and prints a message warning the user that their repository is out-of-date if the two hashes do not match.

closes #856