### PR TITLE
linking to existing OBOOK pages instead of MDs in the ODK repo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ For more details, see
 # Where to get help
 
 - _How-to guides_:
-  - How to [create your first repository](https://github.com/INCATools/ontology-development-kit/blob/master/docs/CreatingRepo.md) with the ODK
+  - How to [create your first repository](https://oboacademy.github.io/obook/howto/odk-create-repo/) with the ODK
   - How to [add license, title and description to your ontology](https://github.com/INCATools/ontology-development-kit/blob/master/docs/License.md)
-  - How to [import large ontologies efficiently](https://github.com/INCATools/ontology-development-kit/blob/master/docs/DealWithLargeOntologies.md)
+  - How to [import large ontologies efficiently](https://oboacademy.github.io/obook/howto/deal-with-large-ontologies/)
 - Reference:
-  - Learn about the [different kinds of release artefacts](https://github.com/INCATools/ontology-development-kit/blob/master/docs/ReleaseArtefacts.md)
+  - Learn about the [different kinds of release artefacts](https://oboacademy.github.io/obook/reference/release-artefacts/)
 - Community:
   -  If you have issues, file them here: https://github.com/INCATools/ontology-development-kit/issues
   -  We also have an active community on Slack; you can request access by making a ticket [here](https://github.com/INCATools/ontology-development-kit/issues) as well


### PR DESCRIPTION
closes #874
This PR changes the links in the _Where to get help_ section of the README to refer to existing OBOOK pages instead of probably outdated MDs contained in the ODK repository. 
Affected links:
* **create your first repository** now links to https://oboacademy.github.io/obook/howto/odk-create-repo/
* **import large ontologies efficiently** now links to https://oboacademy.github.io/obook/howto/deal-with-large-ontologies/
* **different kinds of release artefacts** now links to https://oboacademy.github.io/obook/reference/release-artefacts/