### PR TITLE
Default component goal should be restricted to owl

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -538,9 +538,9 @@ recreate-%:
 no-mirror-recreate-%:
 	$(MAKE) COMP=true IMP=false IMP_LARGE=false MIR=false PAT=true $(COMPONENTSDIR)/$*.owl -B
 
-$(COMPONENTSDIR)/%: | $(COMPONENTSDIR)
+$(COMPONENTSDIR)/%.owl: | $(COMPONENTSDIR)
 	touch $@
-.PRECIOUS: $(COMPONENTSDIR)/%
+.PRECIOUS: $(COMPONENTSDIR)/%.owl
 
 {% for component in project.components.products %}
 {% if component.source is not none %}

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -539,7 +539,7 @@ no-mirror-recreate-%:
 	$(MAKE) COMP=true IMP=false IMP_LARGE=false MIR=false PAT=true $(COMPONENTSDIR)/$*.owl -B
 
 $(COMPONENTSDIR)/%.owl: | $(COMPONENTSDIR)
-	touch $@
+	test -f $@ || touch $@
 .PRECIOUS: $(COMPONENTSDIR)/%.owl
 
 {% for component in project.components.products %}


### PR DESCRIPTION
As it turns out, having a general goal for files in the components directory was a mistake for various reasons (see https://github.com/monarch-initiative/mondo-ingest/pull/299; in a nutshell, you cant overwrite a wildcard goal in make with another more specific wildcard goal - only with a concrete goal without wildcards). 

This PR should:

- Check of a component with the file extension `.owl` exists (i.e. other file formats are unaffected).
- Only if it does not exist, create an empty file (this way, the makegoal also does not needlessly cause all downstream goals to update)

cc @joeflack4 