### PR TITLE
Run the test suite when new commits are added to a PR.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,7 @@ on:
       - master
     types:
       - opened
+      - synchronize
     paths-ignore:
       - '**.md'
       - 'CITATION.cff'


### PR DESCRIPTION
Update the configuration of the main CI workflow to trigger a CI check not only when a PR is initially opened, but also when new commits are pushed to it ("synchronize" event).

The reason for not triggering new CI checks when a PR is updated was to avoid too many runs of the test suite, but this was before we added a path-based ignore rule that prevents the test suite from being run on changes that do not affect any running code. With such a rule in place, avoiding automatically triggered CI checks is no longer warranted.