### PR TITLE
Fix the entrypoint script when ODK_USER_ID is 0.

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ x$ODK_USER_ID = x0 ]; then
-    exec $@
+    exec "$@"
 fi
 
 REAL_USER_ID=${ODK_USER_ID:-1000}


### PR DESCRIPTION
When we run with ODK_USER_ID=0, meaning the process inside the container must run under the identify of the superuser, make sure the arguments to the entrypoint script are quoted before exec'ing.

closes #899