### PR TITLE
Run under root by default unless ODK_USER_ID is explicitly set.

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ x$ODK_USER_ID = x0 ]; then
+if [ -z "$ODK_USER_ID" -o "$ODK_USER_ID" = 0 ]; then
     exec "$@"
 fi
 


### PR DESCRIPTION
This PR changes the entry point script so that it defaults to run the inner processes as root, unless the `ODK_USER_ID` variable is explicitly set to something else than zero.

This avoids breaking things for users who for some reasons do not pass the `ODK_USER_ID` variable when they invoke the ODK – which includes Windows users, since the `run.bat` script has never been updated to pass that variable.