### PR TITLE
Execute ammonite with java explicitly

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -69,7 +69,7 @@ RUN wget -nv https://github.com/owlcollab/owltools/releases/download/$OWLTOOLS_V
 RUN wget -nv https://github.com/lihaoyi/Ammonite/releases/download/$AMMONITE_VERSION/2.13-$AMMONITE_VERSION \
         -O /tools/amm && \
     chmod 755 /tools/amm && \
-    /tools/amm /dev/null
+    java -cp /tools/amm ammonite.AmmoniteMain /dev/null
 
 # Install RDF/XML validation script
 COPY scripts/check-rdfxml.sh /tools/check-rdfxml


### PR DESCRIPTION
This is not necessary when using the normal local build, but it is when running multiarch builds.

Should we merge this to master as well?