### PR TITLE
Add v1.4.1 and v1.4.2 release information to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ A full record of all planned changes can be seen [here](https://github.com/INCAT
 
 - Added a `test_fast` goal that runs all ontology QC checks without refreshing imports or rebuilding components.
 
+# v1.4.2
+
+- Apache Jena updated to version 4.9.0
+- Soufflé updated to version 2.4
+- Fastobo-validator updated to version 0.4.6
+- Ammonite updated to version 2.5.9
+- Several Python packages updated, including:
+  - oaklib 0.5.17
+  - sssom 0.3.40
+  - sssom-schema 0.15.0
+  - linkml 1.5.7
+- /!\ The `bioregistry` dependency is removed in favour of the `curies` package
+
+# v1.4.1
+
+- New [ROBOT version 1.9.4](https://github.com/ontodev/robot/releases/tag/v1.9.4)
+- Newer versions of several Python packages, including:
+  - oaklib 0.5.6
+  - bioregistry 0.9.15
+  - linkml 1.5.2
+
 # v1.4
 
 A full record of all changes can be seen [here](https://github.com/INCATools/ontology-development-kit/milestone/6?closed=1).


### PR DESCRIPTION
@gouttegd shouldnt this information be in the changelog, or is all the relevant information only kept under the v.1.4 section?