### PR TITLE
Update `illegal-date-violation.sparql` to accept `xsd:dateTime`

### DIFF
--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -632,12 +632,14 @@ SELECT ?term ?term_tracker ?term_tracker_type WHERE {
 ^^^ src/sparql/illegal-date-violation.sparql
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT DISTINCT ?term ?property ?value WHERE
 {
-  VALUES ?property {dct:date dct:issued dct:created}
+  VALUES ?property {dct:date dct:issued dct:created oboInOwl:creation_date}
   ?term ?property ?value .
   FILTER (datatype(?value) != xsd:date || !regex(str(?value), '^\\d{4}-\\d\\d-\\d\\d$'))
+  FILTER (datatype(?value) != xsd:dateTime || !regex(str(?value), '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z'))
 }
 {% endif %}
 


### PR DESCRIPTION
Related to https://github.com/obophenotype/cell-ontology/pull/2066

Also adds the property `oboInOwl:creation_date` to the list of properties to check.