### PR TITLE
Make cargo use the "sparse" protocol to download the creates index.

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -84,7 +84,7 @@ RUN wget -nv https://github.com/fastobo/fastobo-validator/archive/refs/tags/v$FA
         -O /build/fastobo-validator-$FASTOBO_VALIDATOR_VERSION.tar.gz && \
     tar xf fastobo-validator-$FASTOBO_VALIDATOR_VERSION.tar.gz && \
     cd fastobo-validator-$FASTOBO_VALIDATOR_VERSION && \
-    cargo build --release && \
+    cargo build --release -Z sparse-registry && \
     install -D -m 755 target/release/fastobo-validator /staging/full/usr/bin/fastobo-validator && \
     cd /build && \
     rm -rf fastobo-validator-$FASTOBO_VALIDATOR_VERSION fastobo-validator-$FASTOBO_VALIDATOR_VERSION.tar.gz /root/.cargo
@@ -94,7 +94,7 @@ RUN wget -nv https://github.com/ontodev/rdftab.rs/archive/refs/tags/v$RDFTAB_VER
         -O /build/rdftab.tar.gz && \
     tar xf rdftab.tar.gz && \
     cd rdftab.rs-$RDFTAB_VERSION && \
-    cargo build --release && \
+    cargo build --release -Z sparse-registry && \
     install -D -m 755 target/release/rdftab /staging/full/usr/bin/rdftab && \
     cd /build && \
     rm -rf rdftab.rs-$RDFTAB_VERSION rdftab.tar.gz /root/.cargo


### PR DESCRIPTION
The default protocol that Cargo is using to download its index of crates is somehow too resource-consuming when the ODK is built under BuildKit (to build multiarch image). So we force Cargo to use the new HTTP-based "sparse" protocol, which is supposedly much more efficient and does not seem to cause issue with BuildKit.

This is the same as #933, but applied to the 1.4 branch.