### PR TITLE
Re-enable the LightRDF-based RDF/XML check.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -622,8 +622,11 @@ class OntologyProject(JsonSchemaMixin):
     robot_report : Dict[str, Any] = field(default_factory=lambda: ReportConfig().to_dict())
     """Block that includes settings for ROBOT report, ROBOT verify and additional reports that are generated"""
 
-    ensure_valid_rdfxml : bool = False
+    ensure_valid_rdfxml : bool = True
     """When enabled, ensure that any RDF/XML product file is valid"""
+
+    extra_rdfxml_checks : bool = False
+    """When enabled, RDF/XML product files are checked against additional parsers"""
 
     # product groups
     import_group : Optional[ImportGroup] = None

--- a/scripts/check-rdfxml.sh
+++ b/scripts/check-rdfxml.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/bash
 
-check_lightrdf=0
-check_rdflib=1
-check_jena=1
+check_lightrdf=1
+check_rdflib=0
+check_jena=0
 rdfxml_file=
 
 while [ -n "$1" ]; do

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -285,7 +285,7 @@ show_assets:
 	du -sh $(ASSETS)
 
 check_rdfxml_%: %
-	@check-rdfxml $<
+	@check-rdfxml {% if project.extra_rdfxml_checks %}--jena --rdflib{% endif %} $<
 
 .PHONY: check_rdfxml_assets
 check_rdfxml_assets: $(foreach product,$(MAIN_PRODUCTS),check_rdfxml_$(product).owl)


### PR DESCRIPTION
(This is the same as #928, but targeting the `dev` branch for testing purposes.)

The ODK used to have a validation check that ensured that RDF/XML files were valid. The check was based on LightRDF, whichwas fast enough to make it possible to enable the check by default.

We had to disable that check because of a bug in LightRDF that caused the library to sometimes fail to parse perfectly valid RDF/XML files (#745). That bug has been fixed, so now we can re-enable the check by default.

The check-rdfxml script is now invoked by default, and by default is uses the fast LightRDF-based check. A new ODK option is added (extra_rdfxml_checks): when enabled, it instructs the check-rdfxml script to *also* perform the Jena- and RDFLib-based checks (which are not enabled by default as they are more time-consuming).