### PR TITLE
Update CONTRIBUTING.md.jinja2, fixing broken link

### DIFF
--- a/template/CONTRIBUTING.md.jinja2
+++ b/template/CONTRIBUTING.md.jinja2
@@ -86,7 +86,7 @@ If you have never editted this ontology before, first follow a [general tutorial
 
 ### How to write great issues?
 
-Please refer to the [OBO Academy best practices](https://oboacademy.github.io/obook/lesson/term-request/).
+Please refer to the [OBO Academy term request guide](https://oboacademy.github.io/obook/howto/term-request/).
 
 <a id="great-pulls"></a>
 


### PR DESCRIPTION
The previous link was a 404. I think this is the best replacement.

Coordinated issues:

- https://github.com/linkml/linkml-project-cookiecutter/pull/77