### PR TITLE
Update SSSOM-Java to latest version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV ODK_VERSION $ODK_VERSION
 
 # Software versions
 ENV JENA_VERSION=4.9.0
-ENV SSSOM_JAVA_VERSION=0.6.2
+ENV SSSOM_JAVA_VERSION=0.7.3
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:
 # docker run -v $HOME/.coursier/cache/v1:/tools/.coursier-cache ...


### PR DESCRIPTION
This PR updates the version of SSSOM-Java (both the ROBOT plugin and the standalone command-line tool) to the [latest version (0.7.3)](https://github.com/gouttegd/sssom-java/releases/tag/sssom-java-0.7.3). This version notably provides:

* support for “reconciliating” the IRIs within a mapping set against a so-called [Extended Prefix Map](https://github.com/cthoyt/curies/blob/main/docs/source/struct.rst#extended-prefix-maps);
* support for “splitting” a set along the subject and object ID prefixes (needed for SSSOM export feature outlined in #106).