### PR TITLE
Make qc.yml ODK managed by default

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -586,7 +586,7 @@ class OntologyProject(JsonSchemaMixin):
     ci : Optional[List[str]] = field(default_factory=lambda: ['github_actions'])
     """continuous integration defaults; currently available: travis, github_actions, gitlab-ci"""
     
-    workflows : Optional[List[str]] = field(default_factory=lambda: ['docs'])
+    workflows : Optional[List[str]] = field(default_factory=lambda: ['docs', 'qc'])
     """Workflows that are synced when updating the repo. Currently available: docs, diff, qc, release-diff."""
     
     import_pattern_ontology : bool = False

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -737,7 +737,7 @@ branches:
 notifications:
   email:
     - obo-ci-reports-all@groups.io
-{% endif -%}{% if 'github_actions' in project.ci %}
+{% endif -%}{% if (('github_actions' in project.ci) and ('qc' in project.workflows)) %}
 ^^^ .github/workflows/qc.yml
 # Basic ODK workflow
 

--- a/template/src/scripts/update_repo.sh.jinja2
+++ b/template/src/scripts/update_repo.sh.jinja2
@@ -30,7 +30,7 @@ cp -n target/$OID/.travis.yml $ROOTDIR/
 {%- endif -%}{% if 'github_actions' in project.ci %}
 mkdir -p $ROOTDIR/.github
 mkdir -p $ROOTDIR/.github/workflows
-cp {% if 'qc' not in project.workflows %}-n {% endif %}target/$OID/.github/workflows/qc.yml $ROOTDIR/.github/workflows/qc.yml
+{% if 'qc' in project.workflows %}cp target/$OID/.github/workflows/qc.yml $ROOTDIR/.github/workflows/qc.yml{% endif %}
 {% if 'diff' in project.workflows %}cp target/$OID/.github/workflows/diff.yml $ROOTDIR/.github/workflows/diff.yml{% endif %}
 {% if 'release-diff' in project.workflows %}cp target/$OID/.github/workflows/release-diff.yml $ROOTDIR/.github/workflows/release-diff.yml{% endif %}
 {% if project.documentation is not none %}


### PR DESCRIPTION
This PR:
- Makes qc.yml ODK-managed by default
- Makes it possible to despense with the qc.yml from the beginning, by making it excludable in the config

Fixes #797 