### PR TITLE
Add `release_annotate_inferred_axioms`

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -609,6 +609,10 @@ class OntologyProject(JsonSchemaMixin):
     """If set to True, the reasoner will be used during the release process. The reasoner is used for three operations:
     reason (the classification/subclassOf hierarchy computaton); materialize (the materialisation of simple existential/
     object property restrictions); reduce (the removal of redundant subclassOf axioms)."""
+    
+    release_annotate_inferred_axioms : bool = False
+    """If set to True, axioms that are inferred during the reasoning process are annotated accordingly, 
+    see https://robot.obolibrary.org/reason."""
 
     release_materialize_object_properties : List[str] = None
     """Define which object properties to materialise at release time."""

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -987,7 +987,7 @@ merge $(patsubst %, -i %, $(OTHER_SRC)) {% endif %}
 # base: A version of the ontology that does not include any externally imported axioms.
 $(ONT)-base.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(IMPORT_FILES)
 	$(ROBOT_RELEASE_IMPORT_MODE) \{% if project.release_use_reasoner %}
-	reason --reasoner {{ project.reasoner }} --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} \{% if project.release_materialize_object_properties is defined and project.release_materialize_object_properties %}
+	reason --reasoner {{ project.reasoner }} --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} --annotate-inferred-axioms {{ project.release_annotate_inferred_axioms }} \{% if project.release_materialize_object_properties is defined and project.release_materialize_object_properties %}
 	materialize {% for iri in project.release_materialize_object_properties %}--term {{iri}} {% endfor %} \{% endif %}{% endif %}
 	relax \{% if project.release_use_reasoner %}
 	reduce -r {{ project.reasoner }} \{% endif %}
@@ -1030,7 +1030,7 @@ $(ONT)-non-classified.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(IMPORT_FILES)
 #	remove --select imports --trim false
 $(ONT)-simple.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(IMPORT_FILES)
 	$(ROBOT_RELEASE_IMPORT_MODE) \{% if project.release_use_reasoner %}
-		reason --reasoner {{ project.reasoner }} --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} \{% endif %}
+		reason --reasoner {{ project.reasoner }} --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} --annotate-inferred-axioms {{ project.release_annotate_inferred_axioms }} \{% endif %}
 		relax \
 		remove --axioms equivalent \
 		relax \
@@ -1058,7 +1058,7 @@ $(ONT)-simple-non-classified.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED
 # removes any axioms that contains one of the ops that not in the whitelist file
 $(ONT)-basic.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(KEEPRELATIONS) $(IMPORT_FILES)
 	$(ROBOT_RELEASE_IMPORT_MODE) \{% if project.release_use_reasoner %}
-		reason --reasoner {{ project.reasoner }} --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} \{% endif %}
+		reason --reasoner {{ project.reasoner }} --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} --annotate-inferred-axioms {{ project.release_annotate_inferred_axioms }} \{% endif %}
 		relax \
 		remove --axioms equivalent \
 		remove --axioms disjoint \

--- a/tests/test-release-reason.yaml
+++ b/tests/test-release-reason.yaml
@@ -1,0 +1,19 @@
+id: rtrai
+title: "Release Test with reasoning and annotating inferred axioms."
+github_org: obophenotype
+repo: rtrai
+report_fail_on: ERROR
+namespaces: 
+  - http://purl.obolibrary.org/obo/RTRAI_
+  - http://purl.obolibrary.org/obo/PATO_
+release_artefacts: 
+  - full
+  - base
+primary_release: full
+release_annotate_inferred_axioms: true
+import_group:
+  products:
+    - id: ro
+      mirror_from: https://raw.githubusercontent.com/INCATools/ontology-development-kit/master/tests/ontologies/ro.owl
+    - id: pato
+      mirror_from: https://raw.githubusercontent.com/INCATools/ontology-development-kit/master/tests/ontologies/pato.owl


### PR DESCRIPTION
Fixes #647

This PR 

- adds a new option release_annotate_inferred_axioms which is `false` by default
- is added to all places that is covered by `release_use_reasoner` (which are three)
- Added a test