### PR TITLE
Generate custom_reports during release process

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -363,7 +363,7 @@ class ReportConfig(JsonSchemaMixin):
         The custom sparql checks available are: 'owldef-self-reference', 'redundant-subClassOf', 'taxon-range', 'iri-range', 'iri-range-advanced', 'label-with-iri', 'multiple-replaced_by', 'term-tracker-uri', 'illegal-date', 'dc-properties'.
     """
 
-    custom_sparql_exports : Optional[List[str]] = field(default_factory=lambda: ['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms'])
+    custom_sparql_exports : Optional[List[str]] = field(default_factory=lambda: ['basic-report', 'edges', 'xrefs', 'obsoletes', 'synonyms'])
     """Chose which custom reports to generate. The related sparql query must be named CHECKNAME.sparql, and be placed in the src/sparql directory."""
 
     sparql_test_on: List[str] = field(default_factory=lambda: ['edit'])

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -106,7 +106,7 @@ endif
 all: all_odk
 
 .PHONY: all_odk
-all_odk: odkversion{% if project.config_hash %} config_check{% endif %} test all_assets{% if project.release_diff %} release_diff{% endif %}
+all_odk: odkversion{% if project.config_hash %} config_check{% endif %} test custom_reports all_assets{% if project.release_diff %} release_diff{% endif %}
 
 .PHONY: test
 test: odkversion {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot_report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}


### PR DESCRIPTION
Fixes #551

I think this makes sense as otherwise, custom reports are never being generated. 

For us the main use case of custom reports is to provide tabular exports of ontology data; and there is no better time to update this then during a release.

Not feeling very strongly about this but makes sense to me.

EDIT: While I was at it I noticed the `class-count-by-prefix` does not exist in ODK, and removed it.