### PR TITLE
Add convenience check if customised ROBOT report config is out of date and update default config

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -44,7 +44,7 @@ RUN wget -nv $ROBOT_JAR \
     wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/bin/robot \
         -O /tools/robot && \
     chmod 755 /tools/robot &&\
-    wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/src/main/resources/report_profile.txt \
+    wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/robot-core/src/main/resources/report_profile.txt \
         -O /tools/robot_report_profile.txt
 
 # Install DOSDPTOOLS.

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -43,7 +43,9 @@ RUN wget -nv $ROBOT_JAR \
         -O /tools/robot.jar && \
     wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/bin/robot \
         -O /tools/robot && \
-    chmod 755 /tools/robot
+    chmod 755 /tools/robot &&\
+    wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/src/main/resources/report_profile.txt \
+        -O /tools/robot_report_profile.txt
 
 # Install DOSDPTOOLS.
 RUN wget -nv https://github.com/INCATools/dosdp-tools/releases/download/v$DOSDP_VERSION/dosdp-tools-$DOSDP_VERSION.tgz && \

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -688,6 +688,8 @@ WARN	duplicate_label_synonym
 ERROR	duplicate_label
 WARN	duplicate_scoped_synonym
 WARN	equivalent_pair
+WARN	equivalent_class_axiom_no_genus
+ERROR	illegal_use_of_built_in_vocabulary
 WARN	invalid_xref
 ERROR	label_formatting
 ERROR	label_whitespace
@@ -698,11 +700,16 @@ WARN	missing_obsolete_label
 ERROR	missing_ontology_description
 ERROR	missing_ontology_license
 ERROR	missing_ontology_title
+WARN	missing_subset_declaration
 INFO	missing_superclass
+WARN	missing_synonymtype_declaration
 ERROR	misused_obsolete_label
+ERROR	misused_replaced_by
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
+ERROR	multiple_equivalent_class_definitions
 ERROR	multiple_labels
+WARN	invalid_entity_uri
 {%- endif %}
 {%- if 'basic' in project.release_artefacts or project.primary_release == 'basic' %}
 ^^^ src/ontology/keeprelations.txt

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -304,6 +304,21 @@ $(REPORTDIR)/$(SRC)-obo-report.tsv: $(SRCMERGED) | $(REPORTDIR)
 $(REPORTDIR)/%-obo-report.tsv: % | $(REPORTDIR)
 	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot_report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif %}{% endif -%} --print 5 -o $@
 
+ROBOT_DEFAULT_REPORT=https://raw.githubusercontent.com/ontodev/robot/master/robot-core/src/main/resources/report_profile.txt
+
+check_for_robot_updates:
+{%- if project.robot_report.custom_profile %}	
+	@wget "$(ROBOT_DEFAULT_REPORT)" -O $(TMPDIR)/report_profile_robot.txt
+	@cut -f2 "$(TMPDIR)/report_profile_robot.txt" | sort > $(TMPDIR)/sorted_tsv2.txt
+	@cut -f2 "$(ROBOT_PROFILE)" | sort > $(TMPDIR)/sorted_tsv1.txt
+	@comm -23 $(TMPDIR)/sorted_tsv2.txt $(TMPDIR)/sorted_tsv1.txt > $(TMPDIR)/missing.txt
+	@echo "Missing tests:"
+	@cat $(TMPDIR)/missing.txt
+	@rm $(TMPDIR)/sorted_tsv1.txt $(TMPDIR)/sorted_tsv2.txt $(TMPDIR)/missing.txt $(TMPDIR)/report_profile_robot.txt
+{%- else %}
+	echo "You are not using a custom profile, so you are getting the joy of the latest ROBOT report!"
+{% endif %}
+
 # ----------------------------------------
 # Release assets
 # ----------------------------------------

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -304,12 +304,9 @@ $(REPORTDIR)/$(SRC)-obo-report.tsv: $(SRCMERGED) | $(REPORTDIR)
 $(REPORTDIR)/%-obo-report.tsv: % | $(REPORTDIR)
 	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot_report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif %}{% endif -%} --print 5 -o $@
 
-ROBOT_DEFAULT_REPORT=https://raw.githubusercontent.com/ontodev/robot/master/robot-core/src/main/resources/report_profile.txt
-
 check_for_robot_updates:
 {%- if project.robot_report.custom_profile %}	
-	@wget "$(ROBOT_DEFAULT_REPORT)" -O $(TMPDIR)/report_profile_robot.txt
-	@cut -f2 "$(TMPDIR)/report_profile_robot.txt" | sort > $(TMPDIR)/sorted_tsv2.txt
+	@cut -f2 "/tools/robot_report_profile.txt" | sort > $(TMPDIR)/sorted_tsv2.txt
 	@cut -f2 "$(ROBOT_PROFILE)" | sort > $(TMPDIR)/sorted_tsv1.txt
 	@comm -23 $(TMPDIR)/sorted_tsv2.txt $(TMPDIR)/sorted_tsv1.txt > $(TMPDIR)/missing.txt
 	@echo "Missing tests:"


### PR DESCRIPTION
Fixes #552 

This PR:

- Adds a convenience check if customised ROBOT report config is out of date 
- updates the default config which we have not done in years.. No drive now to make this dynamic, but created an issue: https://github.com/INCATools/ontology-development-kit/issues/999

```
sh run.sh make check_for_robot_updates
....
Missing tests:
equivalent_class_axiom_no_genus
illegal_use_of_built_in_vocabulary
invalid_entity_uri
missing_subset_declaration
missing_synonymtype_declaration
misused_replaced_by
multiple_equivalent_class_definitions
```