### PR TITLE
Add babelon toolkit to requirements.txt

### DIFF
--- a/requirements.txt.full
+++ b/requirements.txt.full
@@ -2,6 +2,7 @@
 sssom
 oaklib
 linkml
+babelon
 dosdp
 semsql
 

--- a/requirements.txt.lite
+++ b/requirements.txt.lite
@@ -15,3 +15,4 @@ j2cli[yaml]
 j2cli
 lightrdf
 sssom
+babelon


### PR DESCRIPTION
`babelon` is a library to manage multi-lingual ontologies.

The babelon schema is used already by ontologies like [HPO](https://github.com/obophenotype/human-phenotype-ontology/blob/master/src/ontology/hp.Makefile) and [MP](https://github.com/mgijax/mammalian-phenotype-ontology/blob/04ba2825644ec494d0991d8fad16594ab4192e08/src/ontology/mp.Makefile#L112)

The recent babelon release (my pet project last week) allows removing all this boilerplate we needed to hack the linkml conversion process, and also provides some basic functionalities to translate ontologies automatically.

