### PR TITLE
Ensure temporary directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 target/
 bin/
 semantic.cache
-tmp/*
-!tmp/.gitkeep
-!tmp/README.md
+tmp/
 venv/
 .DS_Store
 template/src/patterns/catalog-v001.xml

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -92,7 +92,7 @@ FORMATS_INCL_TSV = $(sort $(FORMATS) tsv)
 RELEASE_ARTEFACTS = $(sort {% for release in project.release_artefacts %}{% if release.startswith('custom-') %}{{ release | replace("custom-","")}}{% else %}$(ONT)-{{ release }}{% endif %} {% endfor %})
 
 ifeq ($(ODK_DEBUG),yes)
-ODK_DEBUG_FILE = $(TMPDIR)/debug.log
+ODK_DEBUG_FILE = debug.log
 SHELL = $(SCRIPTSDIR)/run-command.sh
 endif
 

--- a/template/src/scripts/run-command.sh
+++ b/template/src/scripts/run-command.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-ODK_DEBUG_FILE=${ODK_DEBUG_FILE:-tmp/debug.log}
+ODK_DEBUG_FILE=${ODK_DEBUG_FILE:-debug.log}
 echo "Command: sh $@" >> $ODK_DEBUG_FILE
 /usr/bin/time -a -o $ODK_DEBUG_FILE -f "Elapsed time: %E\nPeak memory: %M kb" /bin/sh "$@"


### PR DESCRIPTION
This PR amends the #994 PR to:

* reset the changes to the top-level `.gitignore` file, which are not needed;
* have the debug file written to `src/ontology/debug.log`, rather than `src/ontology/tmp/debug.log`, thereby avoiding the bug that motivated #994 in the first place altogether.

This way, we simultaneously ensure that the `src/ontology/tmp` directory always exist _and_ remove the need for that directory to exist for the debug mode to work (“belt-and-suspenders” approach).

The use of a `.gitkeep` file to force the existence of `src/ontology/tmp` is _not_ extended to other directories such as `src/ontology/mirror`, `src/ontology/components`, `src/ontology/subsets`, etc. The rationale is that there is no reason for those directories to exist if they are not used (for example, an ontology that does not import any other ontology has no need for `src/ontology/mirror`; an ontology that defines no subsets has no need for `src/ontology/subsets`, etc.); by contrast, `src/ontology/tmp` will always be needed at some point or another.