### PR TITLE
Get version informations from within the ODK image.

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -87,6 +87,11 @@ ENTRYPOINT ["/usr/local/sbin/odkuser-entrypoint.sh"]
 # secure_path is enabled by default in Debian/Ubuntu, disable it
 RUN sed -i '/secure_path/d' /etc/sudoers
 
+# Install a script that provides information about the ODK and its tools
+COPY scripts/odk-info.sh /tools/odk-info
+RUN chmod 755 /tools/odk-info
+RUN sed -i s/@@ODK_IMAGE_VERSION@@/$ODK_VERSION/ /tools/odk-info
+
 # Install the ODK itself.
 COPY odk/make-release-assets.py /tools
 COPY odk/odk.py /tools

--- a/scripts/odk-info.sh
+++ b/scripts/odk-info.sh
@@ -21,6 +21,11 @@ case $1 in
     show_all_python_packages=1
     shift
     ;;
+
+*)
+    echo "Usage: odkinfo [--tools|--all-python|--all]"
+    exit
+    ;;
 esac
 done
 

--- a/scripts/odk-info.sh
+++ b/scripts/odk-info.sh
@@ -36,15 +36,15 @@ fi
 if [ $show_tools_version -eq 1 ]; then
     robot --version
     amm --version
-    echo "DOSDP-Tools v$(dosdp-tools --version | sed -ne 's/^.*version: //p')"
+    echo "DOSDP-Tools v$(dosdp-tools --version | sed -ne 's/^.*version: //;s/,.*$//p')"
     if type -p Konclude > /dev/null ; then
-        echo "Konclude $(Konclude -h | sed -ne 's/^.*Version //p')"
+        echo "Konclude $(Konclude -h | sed -nre 's/^.*Version (.*) - .*$/\1/p')"
     fi
     if type -p jena.version > /dev/null ; then
         echo "Jena v$(jena.version)"
     fi
     if type -p relation-graph > /dev/null ; then
-        echo "Relation-Graph v$(relation-graph --version | sed -ne 's/^.*version: //p')"
+        echo "Relation-Graph v$(relation-graph --version | sed -ne 's/^.*version: //;s/,.*$//p')"
     fi
     if type -p runoak > /dev/null ; then
         echo "Ontology Access Kit v$(python3 -m pip show oaklib | sed -ne 's/^Version: //p')"

--- a/scripts/odk-info.sh
+++ b/scripts/odk-info.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+show_odk_version=1
+show_tools_version=0
+show_all_python_packages=0
+
+while [ -n "$1" ]; do
+case $1 in
+--tools)
+    show_tools_version=1
+    shift
+    ;;
+
+--all-python)
+    show_all_python_packages=1
+    shift
+    ;;
+
+--all)
+    show_tools_version=1
+    show_all_python_packages=1
+    shift
+    ;;
+esac
+done
+
+if [ $show_odk_version -eq 1 ]; then
+    echo "ODK Image @@ODK_IMAGE_VERSION@@"
+fi
+
+if [ $show_tools_version -eq 1 ]; then
+    robot --version
+    amm --version
+    echo "DOSDP-Tools v$(dosdp-tools --version | sed -ne 's/^.*version: //p')"
+    if type -p Konclude > /dev/null ; then
+        echo "Konclude $(Konclude -h | sed -ne 's/^.*Version //p')"
+    fi
+    if type -p jena.version > /dev/null ; then
+        echo "Jena v$(jena.version)"
+    fi
+    if type -p relation-graph > /dev/null ; then
+        echo "Relation-Graph v$(relation-graph --version | sed -ne 's/^.*version: //p')"
+    fi
+    if type -p runoak > /dev/null ; then
+        echo "Ontology Access Kit v$(python3 -m pip show oaklib | sed -ne 's/^Version: //p')"
+    fi
+fi
+
+if [ $show_all_python_packages -eq 1 ]; then
+    echo "Python packages:"
+    python3 -m pip list
+fi

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -126,9 +126,8 @@ reason_test: $(EDIT_PREPROCESSED)
 
 .PHONY: odkversion
 odkversion:
-	echo "ODK Makefile version: $(ODK_VERSION_MAKEFILE) (this is the version of the ODK with which this Makefile was generated, \
-        not the version of the ODK you are running)" &&\
-	echo "ROBOT version (ODK): " && $(ROBOT) --version
+	@echo "ODK Makefile $(ODK_VERSION_MAKEFILE)"
+	@odk-info --tools
 
 {%- if project.config_hash %}
 .PHONY: config_check


### PR DESCRIPTION
This PR:

1) adds a `odk-info` tool inside the ODK image, that shows the version of the image (baked in at build time) and optionally the versions of the most important tools and the Python packages;

2) amends the `odkversion` Makefile goal to show both the version of the ODK that generated the Makefile (“ODK Makefile”, as baked into the Makefile as seed time) *and* the version of the ODK that is currently running (“ODK Image”), as well as the version of the main tools (obtained from the `odk-info` script).

addresses #791 (apart from the "link to documentation" bit, which I believe is overkill anyway).

With this PR, this is what the `odkversion` output looks like:

```sh
$ sh run.sh make odkversion
ODK Makefile v1.5
ODK Image v1.5
ROBOT version 1.9.5
Ammonite REPL & Script-Runner, 2.5.9
DOSDP-Tools v0.19.3, scalaVersion: 2.13.8, sbtVersion: 1.6.2, gitCommit: 943fbcac7c4c6a3f76ff7e3625628f714c6eb6ad
Konclude v0.7.0-1138 - 500e11d9 (Jun 19 2021)
Jena v4.9.0
Relation-Graph v2.3.2, scalaVersion: 2.13.12, sbtVersion: 1.9.7, gitCommit: ee8b19f4b8a3b8316c2b19c33efa9459013973ee
Ontology Access Kit v0.5.25
```