### PR TITLE
Add a `run_as_root` project configuration option.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -510,6 +510,9 @@ class OntologyProject(JsonSchemaMixin):
 
     edit_format : str = "owl"
     """Format in which the edit file is managed, either obo or owl"""
+
+    run_as_root: bool = False
+    """if true, all commands will be executed into the container under the identity of the super-user. Use this if you have custom workflows that require admin rights (e.g. to install Debian packages not provided in the ODK)."""
     
     robot_version: Optional[str] = None
     """Only set this if you want to pin to a specific robot version"""

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -58,8 +58,8 @@ ODK_TAG=${ODK_TAG:-latest}
 ODK_JAVA_OPTS={% if project.robot_java_args is defined and project.robot_java_args|length %}${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}{% else %}${ODK_JAVA_OPTS:--Xmx8G}{% endif %}
 ODK_DEBUG=${ODK_DEBUG:-no}
 
-ODK_USER_ID=${ODK_USER_ID:-$(id -u)}
-ODK_GROUP_ID=${ODK_GROUP_ID:-$(id -g)}
+ODK_USER_ID=${ODK_USER_ID:-{% if project.run_as_root %}0{% else %}$(id -u){% endif %}}
+ODK_GROUP_ID=${ODK_GROUP_ID:-{% if project.run_as_root %}0{% else %}$(id -g){% endif %}}
 
 # Convert OWLAPI_* environment variables to the OWLAPI as Java options
 # See http://owlcs.github.io/owlapi/apidocs_4/org/semanticweb/owlapi/model/parameters/ConfigurationOptions.html


### PR DESCRIPTION
The ODK workflows now run by default under the identity of a non-privilegied used. To run a workflow under the identity of the super-user (which may be needed for example to install custom Debian packages), the `ODK_USER_ID` variable needs either to be explicitly set to zero or to be removed entirely from the `run.sh` script.

For ontologies that have custom workflows that regularly require admin rights, it is more convenient to be able to ask once and for all that all workflows should be run as root, directly in the `*-odk.yaml` configuration file, instead of having to edit the `run.sh` script.