### PR TITLE
Translations: Bugfix, drop columns, new defaults

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -210,13 +210,13 @@ class BabelonTranslationProduct(Product):
     language: str = "en"
     """Language tag (IANA/ISO), e.g 'en', 'fr'."""
     
-    include_not_translated: str = "false"
+    include_not_translated: str = False
     """if include_not_translated is 'false' NOT_TRANSLATED values are removed during preprocessing."""
     
-    update_translation_status: str = "true"
+    update_translation_status: str = True
     """if update_translation_status is 'true', translations where the source_value has changed are relegated to CANDIDATE status."""
     
-    drop_unknown_columns: str = "true"
+    drop_unknown_columns: str = True
     """if drop_unknown_columns is 'true' columns that are not part of the babelon standard are removed during preprocessing."""
     
     auto_translate: bool = False

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -210,13 +210,13 @@ class BabelonTranslationProduct(Product):
     language: str = "en"
     """Language tag (IANA/ISO), e.g 'en', 'fr'."""
     
-    include_not_translated: str = False
+    include_not_translated: bool = False
     """if include_not_translated is 'false' NOT_TRANSLATED values are removed during preprocessing."""
     
-    update_translation_status: str = True
+    update_translation_status: bool = True
     """if update_translation_status is 'true', translations where the source_value has changed are relegated to CANDIDATE status."""
     
-    drop_unknown_columns: str = True
+    drop_unknown_columns: bool = True
     """if drop_unknown_columns is 'true' columns that are not part of the babelon standard are removed during preprocessing."""
     
     auto_translate: bool = False

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -213,8 +213,11 @@ class BabelonTranslationProduct(Product):
     include_not_translated: str = "false"
     """if include_not_translated is 'false' NOT_TRANSLATED values are removed during preprocessing."""
     
-    update_translation_status: str = "false"
+    update_translation_status: str = "true"
     """if update_translation_status is 'true', translations where the source_value has changed are relegated to CANDIDATE status."""
+    
+    drop_unknown_columns: str = "true"
+    """if drop_unknown_columns is 'true' columns that are not part of the babelon standard are removed during preprocessing."""
     
     auto_translate: bool = False
     """if auto_translate is true, missing values are being translated using the babelon toolkit during preprocessing. By default, the toolkit employs LLM-mediated translations using the OpenAI API. This default may change at any time."""

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -960,9 +960,9 @@ $(TRANSLATIONSDIR)/{{ translation.id }}-preprocessed.babelon.tsv: $(TRANSLATIONS
 		$(foreach n,$(TRANSLATE_PREDICATES), --field $(n)) \
 		--output-source-changed $(TRANSLATIONSDIR)/{{ translation.id }}-changed.babelon.tsv  \
 		--output-not-translated $(TRANSLATIONSDIR)/{{ translation.id }}-not-translated.babelon.tsv \
-		--include-not-translated {{ translation.include_not_translated|default('false') }} \
-		--update-translation-status {{ translation.update_translation_status|default('true') }} \
-		--drop-unknown-columns {{ translation.drop_unknown_columns|default('true') }} \
+		--include-not-translated {{ translation.include_not_translated|default('false')|lower }} \
+		--update-translation-status {{ translation.update_translation_status|default('true')|lower }} \
+		--drop-unknown-columns {{ translation.drop_unknown_columns|default('true')|lower }} \
 		-o $@{% if translation.auto_translate %}
 	echo "Warning: By default, the toolkit employs LLM-mediated translations using the OpenAI API. This default may change at any time"
 	echo "Warning: Never store API keys or other secrets in Makefiles or scripts you have in version control."

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -962,6 +962,7 @@ $(TRANSLATIONSDIR)/{{ translation.id }}-preprocessed.babelon.tsv: $(TRANSLATIONS
 		--output-not-translated $(TRANSLATIONSDIR)/{{ translation.id }}-not-translated.babelon.tsv \
 		--include-not-translated {{ translation.include_not_translated|default('false') }} \
 		--update-translation-status {{ translation.update_translation_status|default('true') }} \
+		--drop-unknown-columns {{ translation.drop_unknown_columns|default('true') }} \
 		-o $@{% if translation.auto_translate %}
 	echo "Warning: By default, the toolkit employs LLM-mediated translations using the OpenAI API. This default may change at any time"
 	echo "Warning: Never store API keys or other secrets in Makefiles or scripts you have in version control."
@@ -983,7 +984,7 @@ $(TRANSLATIONSDIR)/%.synonyms.owl: $(TRANSLATIONSDIR)/%.synonyms.tsv
 .PRECIOUS: $(TRANSLATIONSDIR)/%.synonyms.owl
 
 $(TRANSLATIONSDIR)/%.babelon.owl: $(TRANSLATIONSDIR)/%-preprocessed.babelon.tsv
-	$(BABELONPY) convert $(TMPDIR)/$*.babelon.tsv --output-format owl -o $@.tmp
+	$(BABELONPY) convert $< --output-format owl -o $@.tmp
 	$(ROBOT) merge -i $@.tmp \
 		annotate \
 			--ontology-iri $(ONTBASE)/translations/$*.babelon.owl \


### PR DESCRIPTION
This PR:

- Changes a few default values for the new international edition
- Adds a new feature to drop unsupported columns during the preparation process
- Fixes a wrong references in the owl conversion of the translations