### PR TITLE
Change default of base_merge_drop_equivalent_class_axioms

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -335,8 +335,8 @@ class ImportGroup(ProductGroup):
     use_base_merging: bool = False
     """If set to true, mirrors will be merged before determining a suitable seed. This can be a quite costly process."""
     
-    base_merge_drop_equivalent_class_axioms: bool = True
-    """If set to true, equivalent class axioms will be removed before extracting a module with the base-merging process."""
+    base_merge_drop_equivalent_class_axioms: bool = False
+    """If set to true, equivalent class axioms will be removed before extracting a module with the base-merging process. Do not activate this feature unless you are positive that your base merging process only leverages true base files, with asserted subclass axioms."""
 
     exclude_iri_patterns: Optional[List[str]] = None
     """List of IRI patterns. If set, IRIs matching and IRI pattern will be removed from the import."""


### PR DESCRIPTION
This is a temporary fix.

@dosumis wanted us to add "equivalent class removal" as a default to ODK, and in principle, we all agreed.

However, there is this is the fundamental issue:

1. we can only drop equivalent class axioms if we have a “true base”, i.e. the subclass axioms are asserted
1. we do not have true base yet - because its shipped the next ODK 1.5.

To not break everything everywhere with the new ODK release, we discussed to make this feature opt-in for now, and document it a bit bettter.