### PR TITLE
HOTFIX: Fix the qc.yml to not run mirrors

### DIFF
--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -793,7 +793,7 @@ jobs:
       - name: Run ontology QC checks
         env:
           DEFAULT_BRANCH: {{ project.git_main_branch }}
-        run: cd src/ontology && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' test IMP=false PAT=false
+        run: cd src/ontology && make ROBOT_ENV='ROBOT_JAVA_ARGS=-Xmx6G' test IMP=false PAT=false MIR=false
 {% endif -%}{% if 'gitlab-ci' in project.ci %}
 ^^^ .gitlab-ci.yml
 # Basic ODK workflow to run ontology QC checks


### PR DESCRIPTION
This is necessary to be pushed as a hotfix quickly, as some QC pipelines can run mirrors without failing. 

I didnt notice this because of chicken egg - I couldnt test qc.yml directly, and it failed because it was not able to find the v1.5 ODK release..