### PR TITLE
Add semsimian as fixed dependency

### DIFF
--- a/requirements.txt.full
+++ b/requirements.txt.full
@@ -5,6 +5,7 @@ linkml
 babelon
 dosdp
 semsql
+semsimian
 
 # Secondary dependencies
 click


### PR DESCRIPTION
Since semsimian is critical for many of our workflows, I just add it here just in case https://github.com/INCATools/ontology-access-kit/issues/703#issuecomment-1981750814 becomes a reality.

It was previously a dependency of OAK, but there is talk of making it optional (which makes some sense from the OAK perspective).