### PR TITLE
Reinstate class-count-by-prefix query

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -397,7 +397,7 @@ class ReportConfig(JsonSchemaMixin):
         The custom sparql checks available are: 'owldef-self-reference', 'redundant-subClassOf', 'taxon-range', 'iri-range', 'iri-range-advanced', 'label-with-iri', 'multiple-replaced_by', 'term-tracker-uri', 'illegal-date', 'dc-properties'.
     """
 
-    custom_sparql_exports : Optional[List[str]] = field(default_factory=lambda: ['basic-report', 'edges', 'xrefs', 'obsoletes', 'synonyms'])
+    custom_sparql_exports : Optional[List[str]] = field(default_factory=lambda: ['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms'])
     """Chose which custom reports to generate. The related sparql query must be named CHECKNAME.sparql, and be placed in the src/sparql directory."""
 
     sparql_test_on: List[str] = field(default_factory=lambda: ['edit'])

--- a/template/src/sparql/class-count-by-prefix.sparql
+++ b/template/src/sparql/class-count-by-prefix.sparql
@@ -1,0 +1,10 @@
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix obo: <http://purl.obolibrary.org/obo/>
+
+SELECT ?prefix (COUNT(DISTINCT ?cls) AS ?numberOfClasses) WHERE 
+{
+  ?cls a owl:Class .
+  FILTER (!isBlank(?cls))
+  BIND( STRBEFORE(STRAFTER(str(?cls),"http://purl.obolibrary.org/obo/"), "_") AS ?prefix)
+}
+GROUP BY ?prefix


### PR DESCRIPTION
Fixes #1030. 

This was erroneously removed based on the absence of the query in the default list in odk.py - I realised now that `Makefile.jinja2` also had the default set - which is what caused the issue @anitacaron experienced.

Note: I added the `hotfix` label as a reminder to add this PR to the next minor release.