### PR TITLE
Comment out table reader from mkdocs.yml

### DIFF
--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -1803,7 +1803,7 @@ theme:
     - content.tabs.link
 plugins:
   - search
-  - table-reader
+  #- table-reader (see https://github.com/INCATools/ontology-development-kit/issues/1028)
 markdown_extensions:
   - pymdownx.highlight:
   - pymdownx.inlinehilite


### PR DESCRIPTION
See https://github.com/INCATools/ontology-development-kit/issues/1028

This is not a real fix, but without this, mkdocs.yml is broken when creating a new repo.
