### PR TITLE
Add mermaid 2 to ODK docs

### DIFF
--- a/requirements.txt.full
+++ b/requirements.txt.full
@@ -35,6 +35,7 @@ ontodev-cogs
 ontodev-gizmos
 mkdocs
 mkdocs-material
+mkdocs-mermaid2-plugin
 mkdocs-table-reader-plugin
 funowl
 kgx


### PR DESCRIPTION
This enables us to add nice diagrams like https://monarch-initiative.github.io/ontogpt/phenotype/, widely used in LinkML style docs. 