### PR TITLE
Ensure that ROBOT plugin dir exists before download

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -182,6 +182,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
 # Specific rules for supplementary plugins defined in configuration
 {% if project.robot_plugins is defined %}{% for plugin in project.robot_plugins.plugins %}
 $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar:
+	@mkdir -p $(ROBOT_PLUGINS_DIRECTORY)
 {%- if plugin.mirror_from %}
 	curl -L -o $@ {{ plugin.mirror_from }}
 {%- else %}


### PR DESCRIPTION
Similar to the default goal, we need to make sure that the robot plugin dir exists before external plugins are downloaded.