### PR TITLE
Fix use of ODK_BINDS option.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -108,7 +108,7 @@ if [ -n "$USE_SINGULARITY" ]; then
         -W $WORK_DIR \
         docker://obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"
 else
-    BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /')"
+    BIND_OPTIONS="-v $(echo $VOLUME_BIND | sed 's/,/ -v /g')"
     docker run $ODK_DOCKER_OPTIONS $BIND_OPTIONS -w $WORK_DIR \
         {% if project.use_env_file_docker is sameas True %}--env-file run.sh.env {% else %}-e ROBOT_JAVA_ARGS="$ODK_JAVA_OPTS" -e JAVA_OPTS="$ODK_JAVA_OPTS" -e SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock -e ODK_USER_ID=$ODK_USER_ID -e ODK_GROUP_ID=$ODK_GROUP_ID -e ODK_DEBUG=$ODK_DEBUG {% if project.use_external_date is sameas True %}-e TODAY=`date +%Y-%m-%d` {% endif %}{% endif %}\
         --rm -ti obolibrary/$ODK_IMAGE:$ODK_TAG $TIMECMD "$@"


### PR DESCRIPTION
The run.sh script is supposed to allow specifying extra bindings between the local filesystem and the container, with a `ODK_BINDS` option in the `run.sh.conf` file:

```
ODK_BINDS=/path/to/my/local/dir:/path/to/the/container/mount/point
```

This currently doesn't work when using the Docker (standard) backend because of a single missing `g` option to the sed command that converts the value of `ODK_BINDS` into `-v` options to pass to `docker run`.

This PR simply adds the missing `g` option.