### PR TITLE
Update ROBOT plugins and SSSOM-CLI.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV ODK_VERSION $ODK_VERSION
 
 # Software versions
 ENV JENA_VERSION=4.9.0
-ENV KGCL_JAVA_VERSION=0.3.2
-ENV SSSOM_JAVA_VERSION=0.7.5
+ENV KGCL_JAVA_VERSION=0.4.0
+ENV SSSOM_JAVA_VERSION=0.7.7
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:
 # docker run -v $HOME/.coursier/cache/v1:/tools/.coursier-cache ...


### PR DESCRIPTION
This PR updates the KGCL plugin to version 0.4.0 (which brings, among other things, support for creating properties instead of only classes, and auto-assignation of IDs for newly created entities), and the SSSOM plugin/CLI to version 0.7.7 (which brings the `--update-from-ontology` option to use an ontology to update an existing mapping set).