### PR TITLE
Ugrade base system to Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ COPY scripts/obodash /tools
 RUN chmod +x /tools/obodash && \
     git clone --depth 1 https://github.com/OBOFoundry/OBO-Dashboard.git && \
     cd OBO-Dashboard && \
-    python3 -m pip install -r requirements.txt && \
+    python3 -m pip install -r requirements.txt --break-system-packages && \
     echo " " >> Makefile && \
     echo "build/robot.jar:" >> Makefile && \
     echo "	echo 'skipped ROBOT jar download.....' && touch \$@" >> Makefile && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-i
     xlsx2csv \
     gh \
     nodejs \
+    npm \
     graphviz \
     python3-psycopg2 \
     swi-prolog

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,8 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-i
     npm \
     graphviz \
     python3-psycopg2 \
-    swi-prolog
+    swi-prolog \
+    libpcre3
 
 # Install run-time dependencies for Soufflé.
 RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ publish-multiarch-dev:
 		.
 
 constraints.txt: requirements.txt.full
-	docker run -v $$PWD:/work -w /work --rm -ti obolibrary/odkbuild:latest /work/update-constraints.sh
+	docker run -v $$PWD:/work -w /work --rm -ti obolibrary/odkbuild:latest /work/update-constraints.sh --install-virtualenv
 
 clean-tests:
 	rm -rf target/*

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ docs:
 	@ODK_IMAGE=odklite ./odk.sh python ./odk/schema_documentation.py
 
 # Building docker image
-VERSION = "v1.5"
+VERSION = "v1.6"
 IM=obolibrary/odkfull
 IMLITE=obolibrary/odklite
 ROB=obolibrary/robot

--- a/constraints.txt
+++ b/constraints.txt
@@ -12,12 +12,12 @@ async-lru==2.0.4
 attrs==23.2.0
 Babel==2.15.0
 babelon==0.2.9
-backports.tarfile==1.1.1
+backports.tarfile==1.2.0
 bcp47==0.1.0
 beautifulsoup4==4.12.3
 bidict==0.23.1
 bleach==6.1.0
-bmt==1.4.1
+bmt==1.4.2
 cachetools==5.3.3
 cattrs==23.2.3
 certifi==2024.2.2
@@ -59,13 +59,13 @@ executing==2.0.1
 fastjsonschema==2.19.1
 fastobo==0.12.3
 filelock==3.14.0
-fonttools==4.52.1
+fonttools==4.52.4
 fqdn==1.5.1
 funowl==0.2.3
 ghp-import==2.1.0
 google==3.0.0
 google-api-core==2.19.0
-google-api-python-client==2.130.0
+google-api-python-client==2.131.0
 google-auth==2.29.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
@@ -88,7 +88,7 @@ inflection==0.5.1
 iniconfig==2.0.0
 ipykernel==6.29.4
 ipython==8.24.0
-ipywidgets==8.1.2
+ipywidgets==8.1.3
 isodate==0.6.1
 isoduration==20.11.0
 j2cli==0.3.10
@@ -125,7 +125,7 @@ jupyter_server_terminals==0.5.3
 jupyterlab==4.2.1
 jupyterlab_pygments==0.3.0
 jupyterlab_server==2.27.2
-jupyterlab_widgets==3.0.10
+jupyterlab_widgets==3.0.11
 keyring==25.2.1
 kgcl-rdflib==0.5.0
 kgcl_schema==0.6.8
@@ -177,8 +177,8 @@ ontobio==2.9.0
 ontodev-cogs==0.3.3
 ontodev-gizmos==0.3.2
 ontoportal-client==0.0.4
-openai==1.30.3
-openpyxl==3.1.2
+openai==1.30.4
+openpyxl==3.1.3
 ordered-set==4.1.0
 overrides==7.7.0
 packaging==24.0
@@ -200,7 +200,7 @@ prefixcommons==0.1.12
 prefixmaps==0.2.4
 prologterms==0.0.6
 prometheus_client==0.20.0
-prompt-toolkit==3.0.43
+prompt_toolkit==3.0.45
 pronto==2.5.7
 proto-plus==1.23.0
 protobuf==4.25.3
@@ -211,8 +211,8 @@ pyarrow==15.0.2
 pyasn1==0.6.0
 pyasn1_modules==0.4.0
 pycparser==2.22
-pydantic==2.7.1
-pydantic_core==2.18.2
+pydantic==2.7.2
+pydantic_core==2.18.3
 pydotplus==2.0.2
 PyGithub==2.3.0
 Pygments==2.18.0
@@ -248,7 +248,7 @@ readme_renderer==43.0
 recommonmark==0.7.1
 referencing==0.35.1
 regex==2024.5.15
-requests==2.32.2
+requests==2.32.3
 requests-cache==1.2.0
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
@@ -320,7 +320,7 @@ wcwidth==0.2.13
 webcolors==1.13
 webencodings==0.5.1
 websocket-client==1.8.0
-widgetsnbextension==4.0.10
+widgetsnbextension==4.0.11
 wrapt==1.16.0
 xmltodict==0.13.0
 yamldown==0.1.8

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update && \
         rustc \
         cargo \
         python3-dev \
-        python3-pip \
-        python3-virtualenv
+        python3-pip
 
 # Build the Python packages.
 # On x86_64, most if not all of these packages should be available as

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -44,6 +44,7 @@ COPY constraints.txt /build/constraints.txt
 RUN python3 -m pip install \
         -r /build/requirements.txt.lite \
         -c /build/constraints.txt \
+        --no-warn-script-location \
         --root /staging/lite
 # Then those needed by the odkfull image.
 # After installing those packages, we forcibly remove from the odkfull
@@ -53,6 +54,7 @@ RUN python3 -m pip install \
 RUN python3 -m pip install \
         -c /build/constraints.txt \
         -r /build/requirements.txt \
+        --no-warn-script-location \
         --root /staging/full && \
         cd /staging/lite && \
         find . -type f | while read f ; do rm -f /staging/full/$f ; done && \

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -3,7 +3,7 @@
 # (typically because pre-compiled binaries don't exist for arm64) and
 # we don't want to build directly on the final image (to avoid
 # cluttering the image with build-time dependencies).
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 WORKDIR /build
 
 # Software versions

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer="obo-tools@googlegroups.com"
 
 ENV ROBOT_VERSION=1.9.6

--- a/docker/robot/Dockerfile
+++ b/docker/robot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer="obo-tools@googlegroups.com" 
 
 WORKDIR /tools

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -778,7 +778,7 @@ class ExecutionContext(JsonSchemaMixin):
     project : Optional[OntologyProject] = None
     meta : str = ""
 
-    
+
 @dataclass
 class Generator(object):
     """
@@ -787,7 +787,7 @@ class Generator(object):
     """
 
     ## TODO: consider merging Generator and ExecutionContext?
-    context : ExecutionContext = ExecutionContext()
+    context : ExecutionContext = field(default_factory=ExecutionContext)
 
     def generate(self, input : str) -> str:
         """
@@ -1083,7 +1083,7 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
         print(" 5. See the section under '…or push an existing repository from the command line'")
         print("    E.g.:")
         print("cd {}".format(outdir))
-        print("git remote add origin git\@github.com:{org}/{repo}.git".format(org=project.github_org, repo=project.repo))
+        print("git remote add origin git@github.com:{org}/{repo}.git".format(org=project.github_org, repo=project.repo))
         print("git branch -M {branch}\n".format(branch=project.git_main_branch))
         print("git push -u origin {branch}\n".format(branch=project.git_main_branch))
         print("BE BOLD: you can always delete your repo and start again\n")

--- a/update-constraints.sh
+++ b/update-constraints.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [ "x$1" = x--install-virtualenv ]; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-virtualenv
+fi
+
 virtualenv tmpdir
 . tmpdir/bin/activate
 python3 -m pip install -U pip


### PR DESCRIPTION
This PR updates the base system of all our images to the latest LTR version of Ubuntu, 24.04.

* Some system packages that were previously implicitly installed now need to be explicitly asked for (e.g. `libpcre3`, needed for Konclude, or `npm`, needed to install Obographviz).
* The OBO Dashboard must now be installed with `--break-system-packages`, otherwise `pip` will flatly refuse to install it system-wide.
* We can no longer have `virtualenv` in the builder image, as it messes with the installation of our Python packages.
* The `odk.py` script has some issues with Python 3.12 that need fixing. 

closes #1008