### PR TITLE
Update minor version in Makefile to 1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ docs:
 	@ODK_IMAGE=odklite ./odk.sh python ./odk/schema_documentation.py
 
 # Building docker image
-VERSION = "v1.5"
+VERSION = "v1.6"
 IM=obolibrary/odkfull
 IMLITE=obolibrary/odklite
 ROB=obolibrary/robot


### PR DESCRIPTION
Updating minor version in Makefile, primarily so that my regular `dev` snapshot releases are correctly tagged with 1.6-dev rather than 1.5-dev.