### PR TITLE
Adding = operator to ENV assignments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ ARG ODKLITE_TAG=latest
 FROM obolibrary/odklite:${ODKLITE_TAG}
 LABEL maintainer="obo-tools@googlegroups.com"
 
-ENV PATH "/tools/apache-jena/bin:/tools/sparqlprog/bin:$PATH"
+ENV PATH="/tools/apache-jena/bin:/tools/sparqlprog/bin:$PATH"
 
 ARG ODK_VERSION 0.0.0
-ENV ODK_VERSION $ODK_VERSION
+ENV ODK_VERSION=$ODK_VERSION
 
 # Software versions
 ENV JENA_VERSION=4.9.0
@@ -16,7 +16,7 @@ ENV SSSOM_JAVA_VERSION=0.7.7
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:
 # docker run -v $HOME/.coursier/cache/v1:/tools/.coursier-cache ...
-ENV COURSIER_CACHE "/tools/.coursier-cache"
+ENV COURSIER_CACHE="/tools/.coursier-cache"
 
 # Add NodeSource package repository (needed to get recent versions of Node)
 COPY thirdpartykeys/nodesource.gpg /usr/share/keyrings/nodesource.gpg
@@ -103,7 +103,7 @@ RUN chmod +x /tools/obodash && \
 
 # Install relation-graph
 ENV RG=2.3.2
-ENV PATH "/tools/relation-graph/bin:$PATH"
+ENV PATH="/tools/relation-graph/bin:$PATH"
 RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RG/relation-graph-cli-$RG.tgz \
 && tar -zxvf relation-graph-cli-$RG.tgz \
 && mv relation-graph-cli-$RG /tools/relation-graph \

--- a/docker/robot/Dockerfile
+++ b/docker/robot/Dockerfile
@@ -3,9 +3,9 @@ LABEL maintainer="obo-tools@googlegroups.com"
 
 WORKDIR /tools
 
-ENV ROBOT v1.9.6
+ENV ROBOT=v1.9.6
 ARG ROBOT_JAR=https://github.com/ontodev/robot/releases/download/$ROBOT/robot.jar
-ENV ROBOT_JAR ${ROBOT_JAR}
+ENV ROBOT_JAR=${ROBOT_JAR}
 
 RUN apt-get update &&\
   apt-get upgrade -y &&\
@@ -20,6 +20,6 @@ RUN curl -L $ROBOT_JAR -o /tools/robot.jar &&\
     chmod +x /tools/robot && \
     chmod +x /tools/robot.jar
   
-ENV PATH "/tools/:$PATH"
+ENV PATH="/tools/:$PATH"
 RUN echo "Keep me in sync with obolibrary/odkfull!"
 CMD robot -h


### PR DESCRIPTION
During the last runs of docker build I got a warning "- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line X)", which is due to the fact that the "equal-less form is deprecated and may be removed in the future" (thanks @gouttegd for the note). Here I add equal signs to all such cases across the project.