### PR TITLE
Update SSSOM-Java.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV ODK_VERSION=$ODK_VERSION
 # Software versions
 ENV JENA_VERSION=4.9.0
 ENV KGCL_JAVA_VERSION=0.4.0
-ENV SSSOM_JAVA_VERSION=0.7.7
+ENV SSSOM_JAVA_VERSION=0.9.0
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:
 # docker run -v $HOME/.coursier/cache/v1:/tools/.coursier-cache ...


### PR DESCRIPTION
This PR simply bumps the SSSOM-Java (ROBOT plugin and command line tool) to the latest 0.9.0 version.