### PR TITLE
Make sure the SSH socket belongs to `odkuser`.

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,5 +10,6 @@ REAL_GROUP_ID=${ODK_GROUP_ID:-1000}
 groupadd -o -g $REAL_GROUP_ID odkuser
 useradd -o -s /bin/bash -u $REAL_USER_ID -g $REAL_GROUP_ID -c "ODK User" -m odkuser
 PATH=$PATH:/home/odkuser/.local/bin
+[ -S /run/host-services/ssh-auth.sock ] && chown odkuser /run/host-services/ssh-auth.sock
 
 exec sudo -H -E -u odkuser "$@"


### PR DESCRIPTION
When we run under a non-privileged user account (which is the default situation), we need to make the SSH authentication socket, if it exists, belongs to the `odkuser` account. Under some conditions, Docker may create that socket as belonging to root by default.