### PR TITLE
Make `odk.py seed` more robust

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -996,7 +996,7 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
             raise Exception('max one repo; current={}'.format(repo))
         repo = repo[0]
     else:
-        repo = None
+        repo = "noname"
     mg.load_config(config,
                    imports=dependencies,
                    title=title,

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -993,7 +993,7 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
     mg = Generator()
     if len(repo) > 0:
         if len(repo) > 1:
-            raise Exception('max one repo; current={}'.format(repo))
+            raise click.ClickException('max one repo; current={}'.format(repo))
         repo = repo[0]
     else:
         repo = "noname"

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -1007,6 +1007,11 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
         project.id = repo
     if outdir is None:
         outdir = "target/{}".format(project.id)
+    if not skipgit:
+        if not "GIT_AUTHOR_NAME" in os.environ and not gitname:
+            raise click.ClickException("missing Git username; set GIT_AUTHOR_NAME or use --gitname")
+        if not "GIT_AUTHOR_EMAIL" in os.environ and not gitemail:
+            raise click.ClickException("missing Git email; set GIT_AUTHOR_EMAIL or use --gitemail")
     if clean:
         if os.path.exists(outdir):
             shutil.rmtree(outdir)


### PR DESCRIPTION
The `seed` command of the `odk.py` script is quite fragile, in that it will easily and loudly crash out when it used incorrectly.

A) Called with no positional arguments (`odk.py seed`):

This causes a crash because the `repo` variable is then set to `None`, while the Jinja template expects a string (or at least something that has a `upper()` method):

```
Traceback (most recent call last):
  File "/tools/odk.py", line 1112, in <module>
    cli()
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tools/odk.py", line 1041, in seed
    tgts += unpack_files(tdir, mg.generate(srcf))
                               ^^^^^^^^^^^^^^^^^
  File "/tools/odk.py", line 800, in generate
    return template.render( project = self.context.project, env = {"ODK_VERSION": os.getenv("ODK_VERSION")})
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.12/dist-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 339, in top-level template code
  File "/usr/local/lib/python3.12/dist-packages/jinja2/utils.py", line 83, in from_obj
    if hasattr(obj, "jinja_pass_arg"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
jinja2.exceptions.UndefinedError: 'None' has no attribute 'upper'
```

This PR fixes that by setting the `repo` variable to `noname` rather than `None`, resulting in the seeding process successfully creating a `noname` repository.

B) Called with too many positional arguments (`odk.py seed repo1 repo2`)

Only one positional argument is expected. The error condition is correctly caught early, but it still yields an unhelpful stack trace:

```
Traceback (most recent call last):
  File "/tools/odk.py", line 1112, in <module>
    cli()
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tools/odk.py", line 996, in seed
    raise Exception('max one repo; current={}'.format(repo))
Exception: max one repo; current=('a', 'b')
```

We fix that here by raising a `ClickException` rather than a raw `Exception`; Click can intercept those and display only the error message rather than a full stack trace.

C) Missing Git username and/or email

Unless `--skipgit` is used, the seeding process needs a Git username and email to pass to Git to create the first commit once the repository is initialised. If for some reason we don’t have a username and/or an email address, this will cause an uncaught exception quite late in the seedingprocess, after all the files have been generated:

```
ERROR:root:Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'odkuser@b382b06553bd.(none)')

Traceback (most recent call last):
  File "/tools/odk.py", line 1112, in <module>
    cli()
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tools/odk.py", line 1076, in seed
    runcmd("cd {dir}/src/ontology && make && git commit -m 'initial commit' -a && git branch -M {branch} && make prepare_initial_release && git commit -m 'first release'".format(dir=outdir, branch=project.git_main_branch))
  File "/tools/odk.py", line 1106, in runcmd
    raise Exception('Failed: {}'.format(cmd))
Exception: Failed: cd target/noname/src/ontology && make && git commit -m 'initial commit' -a && git branch -M main && make prepare_initial_release && git commit -m 'first release'
```

That error condition should instead be caught early in the script, before even attempting to generate anything. This is what we do here.