### PR TITLE
Fix permissions issue on macOS when seeding.

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -87,7 +87,7 @@ ENTRYPOINT ["/usr/local/sbin/odkuser-entrypoint.sh"]
 # - force Git to accept working on a repository owned by someone else
 RUN sed -i '/secure_path/d' /etc/sudoers && \
     userdel -r ubuntu && \
-    echo "[safe]\n    directory = /work" >> /etc/gitconfig
+    echo "[safe]\n    directory = *" >> /etc/gitconfig
 
 # Install a script that provides information about the ODK and its tools
 COPY --chmod=755 scripts/odk-info.sh /tools/odk-info


### PR DESCRIPTION
Setting Git's configuration option `safe.directory` to `/work` is enough to allow working on a pre-seeded repository (when the repository root is bound to `/work` in the container), but does not work when seeding a new repository, because then the root of the newly created repository is not the `/work` directory itself, but is in fact located two directories below that (under `/work/target/<name>`). The `safe.directory` directive has thus no effect when seeding.

We must set `safe.directory` to `*` instead, to completely disable the permission check regardless of where the repository is. Security-wise, this does not change anything -- that check does not bring any security benefit in the context of the ODK, and we were already disabling it when working on pre-seeded repositories.

closes #1105