### PR TITLE
Write $(SRCMERGED) in OFN format.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -196,7 +196,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar:
 MAIN_PRODUCTS = $(sort $(foreach r,$(RELEASE_ARTEFACTS), $(r)) $(ONT))
 MAIN_GZIPPED  = {% if project.gzip_main %}$(foreach f,$(FORMATS), $(ONT).$(f).gz){% endif %}
 MAIN_FILES    = $(foreach n,$(MAIN_PRODUCTS), $(foreach f,$(FORMATS), $(n).$(f))) $(MAIN_GZIPPED)
-SRCMERGED     = $(TMPDIR)/merged-$(SRC)
+SRCMERGED     = $(TMPDIR)/merged-$(ONT)-edit.ofn
 
 .PHONY: all_main
 all_main: $(MAIN_FILES)


### PR DESCRIPTION
Make sure the `$(SRCMERGED)` intermediate file is always written in OFN format, rather than in the same format than the -edit file.

If `$(SRCMERGED)` is written in OBO format, this can cause some checks made on that file to fail because of some peculiarities of the OBO serialisation that do not accurately reflect the contents of the original -edit file.

closes #1107