### PR TITLE
Automatically set Java -Xmx to 90% of Docker memory.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -63,7 +63,14 @@ if [ -n "$TAG_IN_IMAGE" ]; then
   ODK_IMAGE=$(echo $ODK_IMAGE | awk -F':' '{ print $1 }')
 fi
 ODK_TAG=${ODK_TAG:-latest}
-ODK_JAVA_OPTS={% if project.robot_java_args is defined and project.robot_java_args|length %}${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}{% else %}${ODK_JAVA_OPTS:--Xmx8G}{% endif %}
+{% if project.robot_java_args is defined and project.robot_java_args|length %}
+ODK_JAVA_OPTS=${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}
+{% else %}
+if [ -z "$USE_SINGULARITY" ]; then
+    {% raw %}DEFAULT_MAX_MEM=$(bc <<<"($(docker info --format={{.MemTotal}}) * .9) / (1024*1024*1024)")G{% endraw %}
+fi
+ODK_JAVA_OPTS=${ODK_JAVA_OPTS:--Xmx$DEFAULT_MAX_MEM}
+{% endif %}
 ODK_DEBUG=${ODK_DEBUG:-no}
 
 ODK_USER_ID=${ODK_USER_ID:-{% if project.run_as_root %}0{% else %}$(id -u){% endif %}}

--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -68,6 +68,8 @@ ODK_JAVA_OPTS=${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}
 {% else %}
 if [ -z "$USE_SINGULARITY" ]; then
     {% raw %}DEFAULT_MAX_MEM=$(bc <<<"($(docker info --format={{.MemTotal}}) * .9) / (1024*1024*1024)")G{% endraw %}
+else
+    DEFAULT_MAX_MEM=8G
 fi
 ODK_JAVA_OPTS=${ODK_JAVA_OPTS:--Xmx$DEFAULT_MAX_MEM}
 {% endif %}


### PR DESCRIPTION
When seeding/updating a repo, if the project does not explicitly set any `robot_java_args`, generate code in the run.sh script to automatically compute a default max memory setting that is dependent on the total amount of memory that Docker is allowed to use.

The code is used if (1) we are indeed using Docker (and not Singularity) and (2) no contradicting option is set in ODK_JAVA_OPTS (either in the environment or in a run.sh.conf file).

closes #1074