### PR TITLE
Update KGCL plugin to 0.5.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV ODK_VERSION=$ODK_VERSION
 
 # Software versions
 ENV JENA_VERSION=4.9.0
-ENV KGCL_JAVA_VERSION=0.4.0
+ENV KGCL_JAVA_VERSION=0.5.0
 ENV SSSOM_JAVA_VERSION=0.9.0
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:


### PR DESCRIPTION
This PR updates the KGCL plugin for ROBOT to the latest released version 0.5.0. That version brings only one meaningful (user-visible) change compared to the version currently in the ODK, but it is a rather important one: the ability to refer to nodes by their label rather than their ID.

That is, it makes it possible to write

```
obsolete 'my class'
```

rather than

```
obsolete EX:1234
```