### PR TITLE
Fix publishing of SSSOM mapping sets.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -340,8 +340,7 @@ ASSETS = \
 RELEASE_ASSETS = \
   $(MAIN_FILES) {% if project.import_group is defined %}{% if project.import_group.release_imports %}$(IMPORT_FILES) {% endif %}{% endif %}\
   $(SUBSET_FILES){% if project.robot_report.release_reports %} \
-  $(REPORT_FILES){% endif %}{% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.release_mappings %} \
-  $(MAPPING_FILES){% endif %}{% endif %}
+  $(REPORT_FILES){% endif %}
 
 .PHONY: all_assets
 all_assets: $(ASSETS) {% if project.ensure_valid_rdfxml %}check_rdfxml_assets{% endif %}
@@ -371,7 +370,8 @@ CLEANFILES=$(MAIN_FILES) $(SRCMERGED) $(EDIT_PREPROCESSED)
 
 .PHONY: prepare_release
 prepare_release: all_odk
-	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.use_dosdps %}
+	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.release_mappings %}
+	mkdir -p $(RELEASEDIR)/mappings && cp -rf $(MAPPING_FILES) $(RELEASEDIR)/mappings &&\{% endif %}{% endif %}{% if project.use_dosdps %}
 	mkdir -p $(RELEASEDIR)/patterns && cp -rf $(PATTERN_RELEASE_FILES) $(RELEASEDIR)/patterns &&\{% endif %}
 	rm -f $(CLEANFILES) &&\
 	echo "Release files are now in $(RELEASEDIR) - now you should commit, push and make a release \
@@ -379,7 +379,8 @@ prepare_release: all_odk
 
 .PHONY: prepare_initial_release
 prepare_initial_release: all_assets
-	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.use_dosdps %}
+	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.release_mappings %}
+	mkdir -p $(RELEASEDIR)/mappings && cp -rf $(MAPPING_FILES) $(RELEASEDIR)/mappings &&\{% endif %}{% endif %}{% if project.use_dosdps %}
 	mkdir -p $(RELEASEDIR)/patterns && cp -rf $(PATTERN_RELEASE_FILES) $(RELEASEDIR)/patterns &&\{% endif %}
 	rm -f $(patsubst %, ./%, $(CLEANFILES)) &&\
 	cd $(RELEASEDIR) && git add $(RELEASE_ASSETS)
@@ -1244,7 +1245,7 @@ public_release:
 	$(GITHUB_RELEASE_PYTHON) --release $(TAGNAME) $(RELEASEFILES)
 {% else  %}
 
-RELEASE_ASSETS_AFTER_RELEASE=$(foreach n,$(RELEASE_ASSETS), ../../$(n))
+RELEASE_ASSETS_AFTER_RELEASE=$(foreach n,$(RELEASE_ASSETS), ../../$(n)){% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.release_mappings %} $(foreach n,$(MAPPING_FILES), ../$(n)){% endif %}{% endif %}
 GHVERSION=v$(VERSION)
 
 .PHONY: public_release


### PR DESCRIPTION
Publishing the SSSOM mapping sets (which is not enabled by default, but can be requested with the `release_mappings` option in the SSSOM option group) is broken because the rsync command that should take care of copying the mappings to the top-level directory cannot handle the case where the input files are in a directory located above the current directory (because of rsync's `-R` option).

We fix that by

(1) not including the mapping files in the `RELEASE_ASSETS` variables, so that they are excluded from the rsync command;

(2) adding a new step in the `prepare_release` rule to explicitly copy the mappings from `src/mappings` to the top-level `mappings` directory (similarly to what we already do for the pattern files);

(3) amend the definition of the `RELEASE_ASSETS_AFTER_RELEASE` variable so that it includes the mapping files in their final, top-level location.

closes #1036