### PR TITLE
Set proxy settings for Java applications.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -86,6 +86,27 @@ for owlapi_var in $(env | sed -n s/^OWLAPI_//p) ; do
     ODK_JAVA_OPTS="$ODK_JAVA_OPTS -D$OWLAPI_OPTIONS_NAMESPACE.${owlapi_var%=*}=${owlapi_var#*=}"
 done
 
+# Proxy settings for Java applications
+[ -z "$HTTP_PROXY" ] && [ -n "$http_proxy" ] && HTTP_PROXY=$http_proxy
+if [ -n "$HTTP_PROXY" ]; then
+    proxy_host=$(echo $HTTP_PROXY | sed 's,^https\?://,,; s,:[0-9]\+$,,')
+    proxy_port=$(echo $HTTP_PROXY | sed 's,^.*:\([0-9]\+\)$,\1,')
+    ODK_JAVA_OPTS="$ODK_JAVA_OPTS -Dhttp.proxyHost=$proxy_host"
+    [ "$proxy_port" != "$proxy_host" ] && ODK_JAVA_OPTS="$ODK_JAVA_OPTS -Dhttp.proxyPort=$proxy_port"
+fi
+[ -z "$HTTPS_PROXY" ] && [ -n "$https_proxy" ] && HTTPS_PROXY=$https_proxy
+if [ -n "$HTTPS_PROXY" ]; then
+    proxy_host=$(echo $HTTPS_PROXY | sed 's,^https\?://,,; s,:[0-9]\+$,,')
+    proxy_port=$(echo $HTTPS_PROXY | sed 's,^.*:\([0-9]\+\)$,\1,')
+    ODK_JAVA_OPTS="$ODK_JAVA_OPTS -Dhttps.proxyHost=$proxy_host"
+    [ "$proxy_port" != "$proxy_host" ] && ODK_JAVA_OPTS="$ODK_JAVA_OPTS -Dhttps.proxyPort=$proxy_port"
+fi
+[ -z "$NO_PROXY" ] && [ -n "$no_proxy" ] && NO_PROXY=$no_proxy
+if [ -n "$NO_PROXY" ] ; then
+    no_proxy_hosts=$(echo $NO_PROXY | tr ',' '|')
+    ODK_JAVA_OPTS="$ODK_JAVA_OPTS -Dhttp.nonProxyHosts=$no_proxy_hosts"
+fi
+
 TIMECMD=
 if [ x$ODK_DEBUG = xyes ]; then
     # If you wish to change the format string, take care of using


### PR DESCRIPTION
If we detect in the environment some variables indicating that a HTTP(S) proxy should be used, we translate them into the appropriate Java properties so that Java applications (mostly ROBOT) inside the container know about the proxy.

Specifically, we detect a variable like

```
http_proxy=https://example.net:1234
```

(or `HTTP_PROXY`, as this variable is widely used in both uppercase and lowercase forms) and turn it into

```
-Dhttp.proxyHost=example.net
-Dhttp.proxyPort=1234
```

and similarly for `https_proxy` (or `HTTPS_PROXY`), which is turned into `https.proxyHost` and `https.proxyPort` properties.

We also detect a variable like

```
no_proxy=example.com,example.org
```

(or, again, `NO_PROXY`) and turn it into

```
-Dhttp.noProxyHosts=example.com|example.org
```

as [expected by the Java virtual machine](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html).

closes #1063