### PR TITLE
Allow selective publishing of SSSOM mapping sets.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -189,6 +189,9 @@ class SSSOMMappingSetProduct(Product):
     sssom_tool_options: Optional[str] = ""
     """SSSOM toolkit options passed to the sssom command used to generate this product command"""
 
+    release_mappings: bool = False
+    """If set to True, this mapping set is treated as an artifact to be released."""
+
 @dataclass_json
 @dataclass
 class BabelonTranslationProduct(Product):
@@ -471,6 +474,16 @@ class SSSOMMappingSetGroup(JsonSchemaMixin):
     """If set to True, mappings are copied to the release directory."""
     
     products : Optional[List[SSSOMMappingSetProduct]] = None
+
+    def fill_missing(self):
+        if self.products is None:   # Huh? Ignore.
+            return
+        if self.release_mappings:   # All sets are released
+            released_products = [p for p in self.products]
+        else:   # Only some selected sets are released
+            released_products = [p for p in self.products if p.release_mappings]
+        if len(released_products) > 0:
+            self.released_products = released_products
 
 @dataclass_json
 @dataclass
@@ -769,6 +782,8 @@ class OntologyProject(JsonSchemaMixin):
             self.subset_group.fill_missing()
         if self.pattern_pipelines_group is not None:
             self.pattern_pipelines_group.fill_missing()
+        if self.sssom_mappingset_group is not None:
+            self.sssom_mappingset_group.fill_missing()
 
 @dataclass
 class ExecutionContext(JsonSchemaMixin):

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1246,7 +1246,7 @@ public_release:
 	$(GITHUB_RELEASE_PYTHON) --release $(TAGNAME) $(RELEASEFILES)
 {% else  %}
 
-RELEASE_ASSETS_AFTER_RELEASE=$(foreach n,$(RELEASE_ASSETS), ../../$(n)) $(foreach n,$(RELEASED_MAPPING_FILES), ../$(n))
+RELEASE_ASSETS_AFTER_RELEASE=$(foreach n,$(RELEASE_ASSETS), $(RELEASEDIR)/$(n)) $(foreach n,$(RELEASED_MAPPINGS), $(RELEASEDIR)/mappings/$(n).sssom.tsv)
 GHVERSION=v$(VERSION)
 
 .PHONY: public_release

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -245,10 +245,13 @@ all_subsets: $(SUBSET_FILES)
 
 {% if project.sssom_mappingset_group is defined %}
 MAPPINGS = {% for x in project.sssom_mappingset_group.products %} {{ x.id }}{% endfor %}
+{% if project.sssom_mappingset_group.released_products is defined %}
+RELEASED_MAPPINGS = {% for x in project.sssom_mappingset_group.released_products %} {{ x.id }}{% endfor %}{% endif %}
 {% else %}
 MAPPINGS =
 {% endif %}
-MAPPING_FILES = $(patsubst %, $(MAPPINGDIR)/%.sssom.tsv, $(MAPPINGS))
+MAPPING_FILES = $(foreach p, $(MAPPINGS), $(MAPPINGDIR)/$(p).sssom.tsv)
+RELEASED_MAPPING_FILES = $(foreach p, $(RELEASED_MAPPINGS), $(MAPPINGDIR)/$(p).sssom.tsv)
 
 .PHONY: all_mappings
 all_mappings: $(MAPPING_FILES)
@@ -370,8 +373,8 @@ CLEANFILES=$(MAIN_FILES) $(SRCMERGED) $(EDIT_PREPROCESSED)
 
 .PHONY: prepare_release
 prepare_release: all_odk
-	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.release_mappings %}
-	mkdir -p $(RELEASEDIR)/mappings && cp -rf $(MAPPING_FILES) $(RELEASEDIR)/mappings &&\{% endif %}{% endif %}{% if project.use_dosdps %}
+	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.released_products is defined %}
+	mkdir -p $(RELEASEDIR)/mappings && cp -rf $(RELEASED_MAPPING_FILES) $(RELEASEDIR)/mappings &&\{% endif %}{% endif %}{% if project.use_dosdps %}
 	mkdir -p $(RELEASEDIR)/patterns && cp -rf $(PATTERN_RELEASE_FILES) $(RELEASEDIR)/patterns &&\{% endif %}
 	rm -f $(CLEANFILES) &&\
 	echo "Release files are now in $(RELEASEDIR) - now you should commit, push and make a release \
@@ -379,8 +382,8 @@ prepare_release: all_odk
 
 .PHONY: prepare_initial_release
 prepare_initial_release: all_assets
-	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.release_mappings %}
-	mkdir -p $(RELEASEDIR)/mappings && cp -rf $(MAPPING_FILES) $(RELEASEDIR)/mappings &&\{% endif %}{% endif %}{% if project.use_dosdps %}
+	rsync -R $(RELEASE_ASSETS) $(RELEASEDIR) &&\{% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.released_products is defined %}
+	mkdir -p $(RELEASEDIR)/mappings && cp -rf $(RELEASED_MAPPING_FILES) $(RELEASEDIR)/mappings &&\{% endif %}{% endif %}{% if project.use_dosdps %}
 	mkdir -p $(RELEASEDIR)/patterns && cp -rf $(PATTERN_RELEASE_FILES) $(RELEASEDIR)/patterns &&\{% endif %}
 	rm -f $(patsubst %, ./%, $(CLEANFILES)) &&\
 	cd $(RELEASEDIR) && git add $(RELEASE_ASSETS)
@@ -1243,7 +1246,7 @@ public_release:
 	$(GITHUB_RELEASE_PYTHON) --release $(TAGNAME) $(RELEASEFILES)
 {% else  %}
 
-RELEASE_ASSETS_AFTER_RELEASE=$(foreach n,$(RELEASE_ASSETS), ../../$(n)){% if project.sssom_mappingset_group is defined %}{% if project.sssom_mappingset_group.release_mappings %} $(foreach n,$(MAPPING_FILES), ../$(n)){% endif %}{% endif %}
+RELEASE_ASSETS_AFTER_RELEASE=$(foreach n,$(RELEASE_ASSETS), ../../$(n)) $(foreach n,$(RELEASED_MAPPING_FILES), ../$(n))
 GHVERSION=v$(VERSION)
 
 .PHONY: public_release


### PR DESCRIPTION
We make it possible to publish only _some_ of the SSSOM mapping sets defined in the `sssom_mappingset_group`, by allowing each individual product to have its own `release_mappings` flag.

The group-level flag takes precedence over the product-level flags when it is set to True: in that case, all sets are published (as they currently are), regardless of their individual `release_mapping` flag is they have one.

When the group-level flag is set to False (or absent), then only the mapping sets that have their individual `release_mapping` flag set to True are published, if there are such sets.

Implementation-wise, to avoid cluttering the Makefile template with lots of conditional Jinja code, the logic that determines which sets should be published is coded in the `odk.py` script, using the `fill_missing` feature to automatically add a constructed `released_products` slot in the `sssom_mappingset_group`. The Jinja code in the Makefile template can then just check whether that slot exists, and use it directly if it does.

closes #1035