### PR TITLE
Allow generating the documentation for DOSDP patterns

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -572,10 +572,13 @@ class OntologyProject(JsonSchemaMixin):
 
     repo : str = ""
     """Name of repo (do not include org). E.g. cell-ontology"""
-    
+
+    repo_url : str = ""
+    """URL of the online repository. If set, this must point to a browsable version of the repository root."""
+
     github_org : str = ""
     """Name of github org or username where repo will live. Examples: obophenotype, cmungall"""
-    
+
     git_main_branch : str = "main"
     """The main branch for your repo, such as main, or (now discouraged) master."""
 

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -39,6 +39,7 @@ ROBOT=                      robot --catalog $(CATALOG)
 {% if project.owltools_memory|length %}OWLTOOLS_MEMORY=            {{ project.owltools_memory }}{% endif %}
 OWLTOOLS=                   {% if project.owltools_memory|length %}OWLTOOLS_MEMORY=$(OWLTOOLS_MEMORY) {% endif %}owltools --use-catalog
 RELEASEDIR=                 ../..
+DOCSDIR=                    ../../docs
 REPORTDIR=                  reports
 TEMPLATEDIR=                ../templates
 TMPDIR=                     tmp
@@ -832,25 +833,49 @@ DOSDP_TSV_FILES_DEFAULT = $(wildcard $(PATTERNDIR)/data/default/*.tsv)
 DOSDP_PATTERN_NAMES_DEFAULT = $(strip $(patsubst %.tsv, %, $(notdir $(DOSDP_TSV_FILES_DEFAULT))))
 DOSDP_OWL_FILES_DEFAULT = $(foreach name, $(DOSDP_PATTERN_NAMES_DEFAULT), $(PATTERNDIR)/data/default/$(name).ofn)
 DOSDP_TERM_FILES_DEFAULT = $(foreach name, $(DOSDP_PATTERN_NAMES_DEFAULT), $(PATTERNDIR)/data/default/$(name).txt)
+DOSDP_YAML_FILES_DEFAULT = $(foreach name, $(DOSDP_PATTERN_NAMES_DEFAULT), $(PATTERNDIR)/dosdp-patterns/$(name).yaml)
 
 $(DOSDP_OWL_FILES_DEFAULT): $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_DEFAULT) $(ALL_PATTERN_FILES)
 	if [ $(PAT) = true ] && [ "${DOSDP_PATTERN_NAMES_DEFAULT}" ]; then $(DOSDPT) generate --catalog=$(CATALOG) \
     --infile=$(PATTERNDIR)/data/default/ --template=$(PATTERNDIR)/dosdp-patterns --batch-patterns="$(DOSDP_PATTERN_NAMES_DEFAULT)" \
     --ontology=$< {{ project.dosdp_tools_options }} --outfile=$(PATTERNDIR)/data/default; fi
 
+.PHONY: dosdp-docs-default
+dosdp-docs-default: $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_DEFAULT) $(DOSDP_YAML_FILES_DEFAULT)
+	mkdir -p $(DOCSDIR)/patterns/default
+	$(DOSDPT) docs {{ project.dosdp_tools_options }} --catalog=$(CATALOG) \
+		       --ontology=$< \
+		       --infile=$(PATTERNDIR)/data/default \
+		       --template=$(PATTERNDIR)/dosdp-patterns \
+		       --batch-patterns="$(DOSDP_PATTERN_NAMES_DEFAULT)" \
+		       --outfile=$(DOCSDIR)/patterns/default{% if project.github_org and project.repo %} \
+		       --data-location-prefix=https://github.com/{{ project.github_org }}/{{ project.repo }}/tree/{{ project.git_main_branch }}/src/patterns/data/default{% endif %}
+
 {% if project.pattern_pipelines_group is defined %}
 {% for pipeline in project.pattern_pipelines_group.products %}
 # DOSDP {{ pipeline.id }} pipeline
 
 DOSDP_TSV_FILES_{{ pipeline.id.upper() }} = $(wildcard $(PATTERNDIR)/data/{{ pipeline.id }}/*.tsv)
-DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }} = $(strip $(patsubst %.tsv, %, $(notdir $(DOSDP_TSV_FILES {{ pipeline.id.upper() }}))))
+DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }} = $(strip $(patsubst %.tsv, %, $(notdir $(DOSDP_TSV_FILES_{{ pipeline.id.upper() }}))))
 DOSDP_OWL_FILES_{{ pipeline.id.upper() }} = $(foreach name, $(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }}), $(PATTERNDIR)/data/{{ pipeline.id }}/$(name).ofn)
 DOSDP_TERM_FILES_{{ pipeline.id.upper() }} = $(foreach name, $(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }}), $(PATTERNDIR)/data/{{ pipeline.id }}/$(name).txt)
+DOSDP_YAML_FILES_{{ pipeline.id.upper() }} = $(foreach name, $(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }}), $(PATTERNDIR)/dosdp-patterns/$(name).yaml)
 
 $(DOSDP_OWL_FILES_{{ pipeline.id.upper() }}): $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_{{ pipeline.id.upper() }}) $(ALL_PATTERN_FILES)
 	if [ $(PAT) = true ] && [ "${DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }}}" ]; then $(DOSDPT) generate --catalog=$(CATALOG) \
     --infile=$(PATTERNDIR)/data/{{ pipeline.id }} --template=$(PATTERNDIR)/dosdp-patterns/ --batch-patterns="$(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }})" \
     --ontology=$< {{ pipeline.dosdp_tools_options }} --outfile=$(PATTERNDIR)/data/{{ pipeline.id }}; fi
+
+.PHONY: dosdp-docs-{{ pipeline.id }}
+dosdp-docs-{{ pipeline.id }}: $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_{{ pipeline.id.upper() }}) $(DOSDP_YAML_FILES_{{ pipeline.id.upper() }})
+	mkdir -p $(DOCSDIR)/patterns/{{ pipeline.id }}
+	$(DOSDPT) docs {{ pipeline.dosdp_tools_options }} --catalog=$(CATALOG) \
+		       --ontology=$< \
+		       --infile=$(PATTERNDIR)/data/{{ pipeline.id }} \
+		       --template=$(PATTERNDIR)/dosdp-patterns \
+		       --batch-patterns="$(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }})" \
+		       --outfile=$(DOCSDIR)/patterns/{{ pipeline.id }}{% if project.github_org and project.repo %} \
+		       --data-location-prefix=https://github.com/{{ project.github_org }}/{{ project.repo }}/tree/{{ project.git_main_branch }}/src/patterns/data/{{ pipeline.id }}{% endif %}
 {% endfor -%}
 {% endif -%}
 
@@ -1354,6 +1379,7 @@ DOSDP templates
 * pattern_schema_checks:	Alias of the 'dosdp_validation' command
 * update_patterns:		Pull updated patterns listed in dosdp-patterns/external.txt
 * dosdp-matches-%:		Run the DOSDP matches/query pipeline as configured in your {{ project.id }}-odk.yaml file.
+* dosdp-docs-%:                 Generate the documentation for a given DOSDP pipeline.
 {% endif %}
 Editor utilities:
 * validate_idranges:	Make sure your ID ranges file is formatted correctly

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -848,7 +848,8 @@ dosdp-docs-default: $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_DEFAULT) $(DOSDP_YAML
 		       --infile=$(PATTERNDIR)/data/default \
 		       --template=$(PATTERNDIR)/dosdp-patterns \
 		       --batch-patterns="$(DOSDP_PATTERN_NAMES_DEFAULT)" \
-		       --outfile=$(DOCSDIR)/patterns/default{% if project.github_org and project.repo %} \
+		       --outfile=$(DOCSDIR)/patterns/default{% if project.repo_url %} \
+		       --data-location-prefix={{ project.repo_url }}/src/patterns/data/default{% elif project.github_org and project.repo %} \
 		       --data-location-prefix=https://github.com/{{ project.github_org }}/{{ project.repo }}/tree/{{ project.git_main_branch }}/src/patterns/data/default{% endif %}
 
 {% if project.pattern_pipelines_group is defined %}
@@ -874,7 +875,8 @@ dosdp-docs-{{ pipeline.id }}: $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_{{ pipeline
 		       --infile=$(PATTERNDIR)/data/{{ pipeline.id }} \
 		       --template=$(PATTERNDIR)/dosdp-patterns \
 		       --batch-patterns="$(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }})" \
-		       --outfile=$(DOCSDIR)/patterns/{{ pipeline.id }}{% if project.github_org and project.repo %} \
+		       --outfile=$(DOCSDIR)/patterns/{{ pipeline.id }}{% if project.repo_url %} \
+		       --data-location-prefix={{ project.repo_url }}/src/patterns/data/{{ pipeline.id }}{% elif project.github_org and project.repo %} \
 		       --data-location-prefix=https://github.com/{{ project.github_org }}/{{ project.repo }}/tree/{{ project.git_main_branch }}/src/patterns/data/{{ pipeline.id }}{% endif %}
 {% endfor -%}
 {% endif -%}

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -829,9 +829,9 @@ $(PATTERNDIR)/dospd-patterns/%.yml: download_patterns
 # DOSDP default pipeline
 
 DOSDP_TSV_FILES_DEFAULT = $(wildcard $(PATTERNDIR)/data/default/*.tsv)
-DOSDP_OWL_FILES_DEFAULT = $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.ofn, $(notdir $(wildcard $(PATTERNDIR)/data/default/*.tsv)))
-DOSDP_TERM_FILES_DEFAULT = $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.txt, $(notdir $(wildcard $(PATTERNDIR)/data/default/*.tsv)))
-DOSDP_PATTERN_NAMES_DEFAULT = $(strip $(patsubst %.tsv,%, $(notdir $(wildcard $(PATTERNDIR)/data/default/*.tsv))))
+DOSDP_PATTERN_NAMES_DEFAULT = $(strip $(patsubst %.tsv, %, $(notdir $(DOSDP_TSV_FILES_DEFAULT))))
+DOSDP_OWL_FILES_DEFAULT = $(foreach name, $(DOSDP_PATTERN_NAMES_DEFAULT), $(PATTERNDIR)/data/default/$(name).ofn)
+DOSDP_TERM_FILES_DEFAULT = $(foreach name, $(DOSDP_PATTERN_NAMES_DEFAULT), $(PATTERNDIR)/data/default/$(name).txt)
 
 $(DOSDP_OWL_FILES_DEFAULT): $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_DEFAULT) $(ALL_PATTERN_FILES)
 	if [ $(PAT) = true ] && [ "${DOSDP_PATTERN_NAMES_DEFAULT}" ]; then $(DOSDPT) generate --catalog=$(CATALOG) \
@@ -842,10 +842,10 @@ $(DOSDP_OWL_FILES_DEFAULT): $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_DEFAULT) $(AL
 {% for pipeline in project.pattern_pipelines_group.products %}
 # DOSDP {{ pipeline.id }} pipeline
 
-DOSDP_OWL_FILES_{{ pipeline.id.upper() }} = $(patsubst %.tsv, $(PATTERNDIR)/data/{{ pipeline.id }}/%.ofn, $(notdir $(wildcard $(PATTERNDIR)/data/{{ pipeline.id }}/*.tsv)))
-DOSDP_TERM_FILES_{{ pipeline.id.upper() }} = $(patsubst %.tsv, $(PATTERNDIR)/data/{{ pipeline.id }}/%.txt, $(notdir $(wildcard $(PATTERNDIR)/data/{{ pipeline.id }}/*.tsv)))
 DOSDP_TSV_FILES_{{ pipeline.id.upper() }} = $(wildcard $(PATTERNDIR)/data/{{ pipeline.id }}/*.tsv)
-DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }} = $(strip $(patsubst %.tsv,%, $(notdir $(wildcard $(PATTERNDIR)/data/{{ pipeline.id }}/*.tsv))))
+DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }} = $(strip $(patsubst %.tsv, %, $(notdir $(DOSDP_TSV_FILES {{ pipeline.id.upper() }}))))
+DOSDP_OWL_FILES_{{ pipeline.id.upper() }} = $(foreach name, $(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }}), $(PATTERNDIR)/data/{{ pipeline.id }}/$(name).ofn)
+DOSDP_TERM_FILES_{{ pipeline.id.upper() }} = $(foreach name, $(DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }}), $(PATTERNDIR)/data/{{ pipeline.id }}/$(name).txt)
 
 $(DOSDP_OWL_FILES_{{ pipeline.id.upper() }}): $(EDIT_PREPROCESSED) $(DOSDP_TSV_FILES_{{ pipeline.id.upper() }}) $(ALL_PATTERN_FILES)
 	if [ $(PAT) = true ] && [ "${DOSDP_PATTERN_NAMES_{{ pipeline.id.upper() }}}" ]; then $(DOSDPT) generate --catalog=$(CATALOG) \


### PR DESCRIPTION
This PR adds new targets to the standard Makefile (`dosdp-docs-X`, where _X_ is the name of a DOSDP pipeline) to automatically generate the documentations for DOSDP patterns.

This is inspired by CL’s custom [`pattern_docs` target](https://github.com/obophenotype/cell-ontology/blob/1109cf0f40ad53666eb5b4ebda2635ac6bba45db/src/ontology/cl.Makefile#L204), except there here are using DOSDPTools and its (seemingly undocumented) `docs` subcommand rather than DOSDP, because DOSDP seems to crash on way too many patterns.