### PR TITLE
Correctly set default repository name.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -570,7 +570,7 @@ class OntologyProject(JsonSchemaMixin):
     git_user : str = ""
     """GIT user name (necessary for generating releases)"""
 
-    repo : str = ""
+    repo : str = "noname"
     """Name of repo (do not include org). E.g. cell-ontology"""
     
     github_org : str = ""
@@ -1010,8 +1010,6 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
         if len(repo) > 1:
             raise click.ClickException('max one repo; current={}'.format(repo))
         repo = repo[0]
-    else:
-        repo = "noname"
     mg.load_config(config,
                    imports=dependencies,
                    title=title,


### PR DESCRIPTION
If the ODK seeding configuration file does not define the name of the repository (`repo`) and if no name is explicitly given on the command line, we want to set a default repository name ("noname") to prevent a crash when generating the files.

Unfortunately, the way this was done (#1097) makes any `repo` value defined in the configuration _ignored_, because we:

* first set `repo` to "noname" if we didn't get anything from the command line;
* then call `load_config` with whatever value we have for `repo` (hether it comes from the command line or from our default), and `load_config` takes whatever value we give it and **overrides** any value it may have found in the config file.

So here, we define a default value for `project.repo` at the moment that field is declared (as for all other default values), and do **not** set a default value in the main function.

This way:

* if no `repo` argument is given in the command line, we get the value from the configuration file, or the default value if there is `repo` key in the config file;
* if a `repo` argument is given in the command line, it overrides both any value that may be set in the configuration file, and the default value.