### PR TITLE
Force PIP not to upgrade any Debian-installed Python packages.

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -265,7 +265,7 @@ SecretStorage==3.3.3
 semsimian==0.2.19
 semsql==0.3.3
 Send2Trash==1.8.3
-setuptools==75.3.0
+setuptools==68.1.2
 ShExJSG==0.8.2
 six==1.16.0
 sniffio==1.3.1
@@ -318,7 +318,7 @@ wcwidth==0.2.13
 webcolors==24.8.0
 webencodings==0.5.1
 websocket-client==1.8.0
-wheel==0.44.0
+wheel==0.42.0
 widgetsnbextension==4.0.13
 wrapt==1.16.0
 xmltodict==0.13.0

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update && \
 COPY requirements.txt.full /build/requirements.txt
 COPY requirements.txt.lite /build/requirements.txt.lite
 COPY constraints.txt /build/constraints.txt
-RUN echo "setuptools<72" > /build/pip-constraints.txt
+COPY pip-constraints.txt /build/pip-constraints.txt
 # First the packages needed by the odklite image.
 RUN PIP_CONSTRAINT=/build/pip-constraints.txt python3 -m pip install \
         -r /build/requirements.txt.lite \

--- a/pip-constraints.txt
+++ b/pip-constraints.txt
@@ -1,0 +1,6 @@
+six==1.16.0
+wheel==0.42.0
+pip==24.0
+setuptools==68.1.2
+psycopg2==2.9.9
+gyp==0.1

--- a/update-constraints.sh
+++ b/update-constraints.sh
@@ -2,6 +2,14 @@
 
 set -e
 
+if [ -d /usr/lib/python3/dist-packages ]; then
+    # For any Python package already provided by the system, we must
+    # force PIP to use the exact same version as the one installed
+    find /usr/lib/python3/dist-packages -type d -name '*-info' | \
+        sed -E 's,/usr/lib/python3/dist-packages/(.+)-([^-]+)\.(egg|dist)-info,\1==\2,' \
+        > pip-constraints.txt
+fi
+
 if [ "x$1" = x--install-virtualenv ]; then
     apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-virtualenv
@@ -9,6 +17,7 @@ fi
 
 virtualenv tmpdir
 . tmpdir/bin/activate
+export PIP_CONSTRAINT=$(pwd)/pip-constraints.txt
 python3 -m pip install -U pip
 python3 -m pip install -r requirements.txt.full
 python3 -m pip freeze > constraints.txt


### PR DESCRIPTION
This PR amends the `update-constraints.sh` script to automatically extract from the filesystem the list of Python packages that have already been installed by Debian, and that PIP should not attempt to upgrade to any later version.

In addition to the normal `constraints.txt` file, it generates an additional `pip-constraints.txt` file, to be used to force PIP not to do anything with the system-managed packages.

This has the side-effect of ensuring that we never upgrade to any version of setuptools more recent than 72 (known to cause issues with some packages needed by the ODK), since the version provided by Debian is 68.1.2.