### PR TITLE
Use a dedicated token to create the "update constraints" PR.

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -20,6 +20,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:
+          token: ${{ secrets.WORKFLOW_TOKEN }}
           commit-message: Update constraints.txt
           title: 'Update constraints.txt'
           body: |


### PR DESCRIPTION
When updating the Python constraints, create the PR using a dedicated token instead of the default GITHUB_TOKEN. Using the default token has the side-effect that the PR will not trigger any workflow, which in particular means that the test suite (`build-and-test.yml` workflow) will not be run.

A new token has been created on @gouttegd's account and added to the ODK repository. This commit amend the "update-constraints" workflow to specifically use that token.