### PR TITLE
Improve the “update constraints” mechanism

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   constraints:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:latest
+    # This must be the same image as the one the ODK is built on.
+    container: ubuntu:24.04
     strategy:
       max-parallel: 1
     steps:
@@ -15,7 +16,7 @@ jobs:
       - name: work around permission issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build constraints.txt
-        run: sh update-constraints.sh
+        run: sh update-constraints.sh --in-docker
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,12 +380,15 @@ If the component needs to be built from source, do so in [the Dockerfile for odk
 and install the compiled file(s) in either the `/staging/full` tree or the `/staging/lite` tree, for
 inclusion in `odkfull` or `odklite` respectively.
 
-If the component is a Python package, adds it to the `requirements.txt`
+If the component is a Python package, add it to the `requirements.txt.full`
 file, and *also* in the `requirements.txt.lite` file if it is to be part
 of `odklite`. Please try to avoid version constraints unless you can
 explain why you need one.
 
-Python packages are "frozen" before a release by installing all the
-packages listed in `requirements.txt` into a virtual environment and
-running `python -m pip freeze > constraints.txt` from within that
-environment.
+Python packages are "frozen" so that any subsequent build of the ODK
+will always include the exact same version of every single package. To
+update the frozen list, run `make constraints.txt` in the top-level
+directory. This should be done at least (1) whenever a new package is
+added to `requirements.txt.full`, (2) whenever the base image is
+updated. It can also be done at any time during the development cycle to
+ensure that we pick regular updates of any package we use.

--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,9 @@ publish-multiarch-dev:
 		-t $(IM):dev \
 		.
 
+# This should use the same base image as the one used to build the ODK itself.
 constraints.txt: requirements.txt.full
-	docker run -v $$PWD:/work -w /work --rm -ti obolibrary/odkbuild:latest /work/update-constraints.sh --install-virtualenv
+	docker run -v $$PWD:/work -w /work --rm -ti ubuntu:24.04 /work/update-constraints.sh --in-docker
 
 clean-tests:
 	rm -rf target/*

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -41,6 +41,13 @@ COPY requirements.txt.full /build/requirements.txt
 COPY requirements.txt.lite /build/requirements.txt.lite
 COPY constraints.txt /build/constraints.txt
 COPY pip-constraints.txt /build/pip-constraints.txt
+RUN find /usr/lib/python3/dist-packages -type d -name '*-info' | \
+        sed -E 's,/usr/lib/python3/dist-packages/(.+)-([^-]+)\.(egg|dist)-info,\1==\2,' | \
+        sort > pip-constraints.txt.new && \
+        if ! cmp -s pip-constraints.txt pip-constraints.txt.new ; then \
+             echo "WARNING: Locally derived PIP constraints differ from pre-built constraints!" ;\
+             cat pip-constraints.txt.new ;\
+        fi
 # First the packages needed by the odklite image.
 RUN PIP_CONSTRAINT=/build/pip-constraints.txt python3 -m pip install \
         -r /build/requirements.txt.lite \

--- a/pip-constraints.txt
+++ b/pip-constraints.txt
@@ -1,6 +1,3 @@
-six==1.16.0
-wheel==0.42.0
 pip==24.0
 setuptools==68.1.2
-psycopg2==2.9.9
-gyp==0.1
+wheel==0.42.0

--- a/update-constraints.sh
+++ b/update-constraints.sh
@@ -2,23 +2,35 @@
 
 set -e
 
-if [ -d /usr/lib/python3/dist-packages ]; then
-    # For any Python package already provided by the system, we must
-    # force PIP to use the exact same version as the one installed
-    find /usr/lib/python3/dist-packages -type d -name '*-info' | \
-        sed -E 's,/usr/lib/python3/dist-packages/(.+)-([^-]+)\.(egg|dist)-info,\1==\2,' \
-        > pip-constraints.txt
-fi
+in_docker=0
+[ "x$1" = x--in-docker ] && in_docker=1
 
-if [ "x$1" = x--install-virtualenv ]; then
+if [ $in_docker -eq 1 ]; then
+    # Install the same base Python packages as the one present in the
+    # ODK builder image.
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-virtualenv
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3-dev python3-pip
+
+    # Get the list of the Python packages that were actually installed
+    # so we can instruct PIP to use the same versions of said packages.
+    find /usr/lib/python3/dist-packages -type d -name '*-info' | \
+        sed -E 's,/usr/lib/python3/dist-packages/(.+)-([^-]+)\.(egg|dist)-info,\1==\2,' | \
+        sort > pip-constraints.txt
+
+    # Now additionally install virtualenv, which we will need to
+    # install all ODK packages in a separate environment.
+    apt-get install -y --no-install-recommends python3-virtualenv
+
+    # Make sure we are using below the same version of Python as the
+    # one in the ODK
+    PYTHON_VERSION=$(python3 --version | sed -E 's,^Python 3\.([0-9]+)\.[0-9]+$,3.\1,')
 fi
 
-virtualenv tmpdir
+# The version of Python should match
+virtualenv -p ${PYTHON_VERSION:-3.12} tmpdir
 . tmpdir/bin/activate
-export PIP_CONSTRAINT=$(pwd)/pip-constraints.txt
-python3 -m pip install -U pip
+[ -f pip-constraints.txt ] && export PIP_CONSTRAINT=$(pwd)/pip-constraints.txt
 python3 -m pip install -r requirements.txt.full
 python3 -m pip freeze > constraints.txt
 


### PR DESCRIPTION
This PR builds upon #1126 to make the updating of Python constraints more robust.

The key change is that, when computing the Python constraints, we install all the required Python packages in a **minimal** image that is just `ubuntu:24.04` (same image as the base used to build the ODK) in which we install nothing else than `python3-dev` and `python3-pip`.

Previously, we were installing the Python packages in an image that was the ODK itself (`obolibrary/odkfull:latest`), which was problematic for at least two reasons:

* The final ODK image already contains (obviously) all the Python packages we want. In theory this should not cause any problem because when computing the Python constraints we are working in a virtual environment, but for some packages (at least `setuptools` and `wheels`, and possibly others) this is not enough. Using a minimal image ensures that we are always computing the Python constraints from a clean state.
* This cannot work when we need to reset the Python constraints after updating the base image itself (e.g., when we will upgrade to Ubuntu 26.04), because of a chicken-and-egg problem: we need the new `obolibrary/odkfull:latest` (based on the updated Ubuntu image) to compute the new Python constraints, but we need the new Python constraints to build the new `obolibrary/odkfull:latest`. Previously, we were working around that issue by having a separate, undocumented process specifically to update the Python constraints after a base image upgrade. Now we will be able to use exactly the same process (same `update-constraints.sh` script) both for the regular updates of the Python constraints, and for the “big updates” after a migration to a new base image.

In addition, when building the ODK itself (more precisely, the `odkbuilder` image), we check that the list of system-managed Python packages matches what we are expecting (what was determined by the `update-constraints.sh` script, and stored in `pip-constraints.txt`), and we log a warning if there is a discrepancy (which may happen if a Ubuntu-provided Python package has been updated, e.g. for security reasons, since the last refresh of the constraints -- something that should be unlikely to happen often, but just in case).