### PR TITLE
Back port recent fixes to 1.5 branch

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   constraints:
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:latest
+    # This must be the same image as the one the ODK is built on.
+    container: ubuntu:24.04
     strategy:
       max-parallel: 1
     steps:
@@ -15,7 +16,7 @@ jobs:
       - name: work around permission issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build constraints.txt
-        run: sh update-constraints.sh
+        run: sh update-constraints.sh --in-docker
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,12 +310,15 @@ If the component needs to be built from source, do so in [the Dockerfile for odk
 and install the compiled file(s) in either the `/staging/full` tree or the `/staging/lite` tree, for
 inclusion in `odkfull` or `odklite` respectively.
 
-If the component is a Python package, adds it to the `requirements.txt`
+If the component is a Python package, add it to the `requirements.txt.full`
 file, and *also* in the `requirements.txt.lite` file if it is to be part
 of `odklite`. Please try to avoid version constraints unless you can
 explain why you need one.
 
-Python packages are "frozen" before a release by installing all the
-packages listed in `requirements.txt` into a virtual environment and
-running `python -m pip freeze > constraints.txt` from within that
-environment.
+Python packages are "frozen" so that any subsequent build of the ODK
+will always include the exact same version of every single package. To
+update the frozen list, run `make constraints.txt` in the top-level
+directory. This should be done at least (1) whenever a new package is
+added to `requirements.txt.full`, (2) whenever the base image is
+updated. It can also be done at any time during the development cycle to
+ensure that we pick regular updates of any package we use.

--- a/Makefile
+++ b/Makefile
@@ -168,8 +168,9 @@ publish-multiarch-dev:
 		-t $(IM):dev \
 		.
 
+# This should use the same base image as the one used to build the ODK itself.
 constraints.txt: requirements.txt.full
-	docker run -v $$PWD:/work -w /work --rm -ti obolibrary/odkbuild:latest /work/update-constraints.sh --install-virtualenv
+	docker run -v $$PWD:/work -w /work --rm -ti ubuntu:24.04 /work/update-constraints.sh --in-docker
 
 clean-tests:
 	rm -rf target/*

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -40,7 +40,14 @@ RUN apt-get update && \
 COPY requirements.txt.full /build/requirements.txt
 COPY requirements.txt.lite /build/requirements.txt.lite
 COPY constraints.txt /build/constraints.txt
-RUN echo "setuptools<72" > /build/pip-constraints.txt
+COPY pip-constraints.txt /build/pip-constraints.txt
+RUN find /usr/lib/python3/dist-packages -type d -name '*-info' | \
+        sed -E 's,/usr/lib/python3/dist-packages/(.+)-([^-]+)\.(egg|dist)-info,\1==\2,' | \
+        sort > pip-constraints.txt.new && \
+        if ! cmp -s pip-constraints.txt pip-constraints.txt.new ; then \
+             echo "WARNING: Locally derived PIP constraints differ from pre-built constraints!" ;\
+             cat pip-constraints.txt.new ;\
+        fi
 # First the packages needed by the odklite image.
 RUN PIP_CONSTRAINT=/build/pip-constraints.txt python3 -m pip install \
         -r /build/requirements.txt.lite \

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -557,7 +557,7 @@ class OntologyProject(JsonSchemaMixin):
     git_user : str = ""
     """GIT user name (necessary for generating releases)"""
 
-    repo : str = ""
+    repo : str = "noname"
     """Name of repo (do not include org). E.g. cell-ontology"""
     
     github_org : str = ""
@@ -995,8 +995,6 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
         if len(repo) > 1:
             raise click.ClickException('max one repo; current={}'.format(repo))
         repo = repo[0]
-    else:
-        repo = "noname"
     mg.load_config(config,
                    imports=dependencies,
                    title=title,

--- a/pip-constraints.txt
+++ b/pip-constraints.txt
@@ -1,0 +1,3 @@
+pip==24.0
+setuptools==68.1.2
+wheel==0.42.0

--- a/update-constraints.sh
+++ b/update-constraints.sh
@@ -2,14 +2,35 @@
 
 set -e
 
-if [ "x$1" = x--install-virtualenv ]; then
+in_docker=0
+[ "x$1" = x--in-docker ] && in_docker=1
+
+if [ $in_docker -eq 1 ]; then
+    # Install the same base Python packages as the one present in the
+    # ODK builder image.
     apt-get update
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3-virtualenv
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3-dev python3-pip
+
+    # Get the list of the Python packages that were actually installed
+    # so we can instruct PIP to use the same versions of said packages.
+    find /usr/lib/python3/dist-packages -type d -name '*-info' | \
+        sed -E 's,/usr/lib/python3/dist-packages/(.+)-([^-]+)\.(egg|dist)-info,\1==\2,' | \
+        sort > pip-constraints.txt
+
+    # Now additionally install virtualenv, which we will need to
+    # install all ODK packages in a separate environment.
+    apt-get install -y --no-install-recommends python3-virtualenv
+
+    # Make sure we are using below the same version of Python as the
+    # one in the ODK
+    PYTHON_VERSION=$(python3 --version | sed -E 's,^Python 3\.([0-9]+)\.[0-9]+$,3.\1,')
 fi
 
-virtualenv tmpdir
+# The version of Python should match
+virtualenv -p ${PYTHON_VERSION:-3.12} tmpdir
 . tmpdir/bin/activate
-python3 -m pip install -U pip
+[ -f pip-constraints.txt ] && export PIP_CONSTRAINT=$(pwd)/pip-constraints.txt
 python3 -m pip install -r requirements.txt.full
 python3 -m pip freeze > constraints.txt
 


### PR DESCRIPTION
This PR back ports some recent fixes to the 1.5 maintenance branch (fixes to the "update constraints" system and a fix about how the default repo name is handled in `odk.py`).

It's unclear whether we will need a 1.5.4 release at some point or 1.6 will be ready before that, but just in case, I'd rather have these fixes in the 1.5 branch already.