### PR TITLE
Install the SPARQLProg package system-wide.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ODKLITE_TAG=latest
 FROM obolibrary/odklite:${ODKLITE_TAG}
 LABEL maintainer="obo-tools@googlegroups.com"
 
-ENV PATH="/tools/apache-jena/bin:/tools/sparqlprog/bin:$PATH"
+ENV PATH "/tools/apache-jena/bin:/usr/local/share/swi-prolog/pack/sparqlprog/bin:$PATH"
 
 ARG ODK_VERSION 0.0.0
 ENV ODK_VERSION=$ODK_VERSION
@@ -86,8 +86,7 @@ RUN wget -nv http://archive.apache.org/dist/jena/binaries/apache-jena-$JENA_VERS
     mv /tools/apache-jena-$JENA_VERSION /tools/apache-jena
 
 # Install SPARQLProg.
-RUN swipl -g "pack_install(sparqlprog, [interactive(false)])" -g halt && \
-    ln -sf /root/.local/share/swi-prolog/pack/sparqlprog /tools/
+RUN swipl -g "pack_install(sparqlprog, [interactive(false),global(true)])" -g halt
 
 # Install obographviz
 RUN npm install -g obographviz

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ test_odkfull_programs: test_odklite_programs
 	@./tests/test-program.sh SOUFFLE souffle --version
 	@./tests/test-program.sh JENA jena
 	@./tests/test-program.sh SPARQL sparql --version
+	@./tests/test-program.sh SPARQLPROG pl2sparql -g halt
 
 test_odkdev_programs: test_odkfull_programs
 


### PR DESCRIPTION
When installing the SPARQLProg package using SWIPL, we must install make sure that the package is installed in a system-wide directory (under /usr/local) rather than the home directory of the running user (root). Otherwise only root would be able to use the package.

This PR does that by setting the `global` option to `true` when calling SWIPL’s `pack_install` function. Then we update the running PATH to include the `/usr/local/share/swi-prolog/pack/sparqlprog/bin` directory. And we add SPARQLProg’s `pl2sparql` program to the list of programs to check after a build.

closes #1134