### PR TITLE
Add more tests for running programs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ODKLITE_TAG=latest
 FROM obolibrary/odklite:${ODKLITE_TAG}
 LABEL maintainer="obo-tools@googlegroups.com"
 
-ENV PATH "/tools/apache-jena/bin:/usr/local/share/swi-prolog/pack/sparqlprog/bin:$PATH"
+ENV PATH="/tools/apache-jena/bin:/usr/local/share/swi-prolog/pack/sparqlprog/bin:$PATH"
 
 ARG ODK_VERSION 0.0.0
 ENV ODK_VERSION=$ODK_VERSION

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test_odklite_programs:
 	@./tests/test-program.sh ROBOT robot --version
 	@./tests/test-program.sh DOSDP-TOOLS dosdp-tools -v
 	@./tests/test-program.sh OWLTOOLS owltools --version
+	@./tests/test-program.sh OORT ontology-release-runner --help
 	@./tests/test-program.sh AMMONITE sh amm --help
 	@./tests/test-program.sh JINJANATOR jinjanate --version
 	@./tests/test-program.sh ODK odk.py
@@ -44,6 +45,11 @@ test_odkfull_programs: test_odklite_programs
 	@./tests/test-program.sh JENA jena
 	@./tests/test-program.sh SPARQL sparql --version
 	@./tests/test-program.sh SPARQLPROG pl2sparql -g halt
+	@./tests/test-program.sh OBO-DASHBOARD obodash --help
+	@./tests/test-program.sh RELATION-GRAPH relation-graph --version
+	@./tests/test-program.sh SSSOM-CLI sssom-cli --version
+	@./tests/test-program.sh OAKLIB runoak --help
+	@./tests/test-program.sh SSSOM-PY sssom --version
 
 test_odkdev_programs: test_odkfull_programs
 


### PR DESCRIPTION
We add more tests to ensure that programs bundled with the ODK can at least be invoked normally and are not broken.

Specifically, we test the following programs:

* Owltools' Ontology-Release-Runner,
* the OBO-Dashboard,
* Relation-Graph,
* SSSOM-Java's `sssom-cli` command,
* The Ontology Access Kit's `runoak` command,
* SSSOM-Py's `sssom` commmand.

closes #1087