### PR TITLE
Remove git config --global --add safe.directory from constraints.yml

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v4
-      - name: work around permission issue
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build constraints.txt
         run: sh update-constraints.sh --in-docker
       - name: Create Pull Request


### PR DESCRIPTION
Since the base image does not have git installed, this step currently fails, but it seems v3 and above of `peter-evans/create-pull-request` do not need this.