### PR TITLE
Remove sudo from constraints.yml

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends git
+          apt-get update
+          apt-get install -y --no-install-recommends git
       - name: Checkout main branch
         uses: actions/checkout@v4
       - name: Build constraints.txt


### PR DESCRIPTION
Since sudo is not installed in your ubuntu:24.04 container, removing it avoids the [error](https://github.com/INCATools/ontology-development-kit/actions/runs/12027519909/job/33528700033).

In Docker containers, commands are typically executed as root. Therefore, we don't seem to need sudo.