### PR TITLE
Adding ca-certificates install to constraints.yml

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       max-parallel: 1
     steps:
-      - name: Install Git
+      - name: Install Required Packages
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends git
+          apt-get install -y --no-install-recommends git ca-certificates
       - name: Checkout main branch
         uses: actions/checkout@v4
       - name: Build constraints.txt


### PR DESCRIPTION
Just fumbling in the dark now.. But the error suggests that is needed, and perhaps --no-install-recommends precludes this being installed?

https://github.com/INCATools/ontology-development-kit/actions/runs/12045881518