### PR TITLE
Earth in 2150: fixing constraints.yml part 5

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -6,26 +6,23 @@ on:
 jobs:
   constraints:
     runs-on: ubuntu-latest
-    # This must be the same image as the one the ODK is built on.
-    container: ubuntu:24.04
     strategy:
       max-parallel: 1
     steps:
-      - name: Install Required Packages
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends git ca-certificates
+      - name: Check Docker version
+        # This is to fail early in case docker is not available on the base image..
+        run: docker --version
       - name: Checkout main branch
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false  # Ensure credentials are stored properly
       - name: Build constraints.txt
-        run: sh update-constraints.sh --in-docker
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ubuntu:24.04 \
+          sh update-constraints.sh --in-docker
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOW_TOKEN }}
           commit-message: Update constraints.txt
           title: 'Update constraints.txt'
           body: |

--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -17,13 +17,15 @@ jobs:
           apt-get install -y --no-install-recommends git ca-certificates
       - name: Checkout main branch
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false  # Ensure credentials are stored properly
       - name: Build constraints.txt
         run: sh update-constraints.sh --in-docker
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:
-          token: ${{ secrets.WORKFLOW_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update constraints.txt
           title: 'Update constraints.txt'
           body: |


### PR DESCRIPTION
At my wits end, I now consulted with various AI tools and they say:

```
persist-credentials: false:

Ensures the credentials are correctly stored for subsequent Git operations, preventing authentication issues.
```

This is super annoying.. Now your suggestion (of testing locally) wont even work because the problem is _specifically_ about the last github action step, so you cant really test it anywhere other than in the repo (or in a fork, which is a lot of churn).

I wonder, alternatively, if it would work to run it all in Ubuntu base image, and then

```
run: |
          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ubuntu:24.04 \
          sh update-constraints.sh --in-docker
```

just in the Build constraints.txt step?