### PR TITLE
Add SQLite/SemSQL export format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-i
     automake \
     aha \
     dos2unix \
-    sqlite3 \
     libjson-perl \
     libbusiness-isbn-perl \
     pkg-config \
@@ -101,14 +100,6 @@ RUN chmod +x /tools/obodash && \
     echo "build/robot.jar:" >> Makefile && \
     echo "	echo 'skipped ROBOT jar download.....' && touch \$@" >> Makefile && \
     echo "" >> Makefile
-
-# Install relation-graph
-ENV RG=2.3.2
-ENV PATH="/tools/relation-graph/bin:$PATH"
-RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RG/relation-graph-cli-$RG.tgz \
-&& tar -zxvf relation-graph-cli-$RG.tgz \
-&& mv relation-graph-cli-$RG /tools/relation-graph \
-&& chmod +x /tools/relation-graph
 
 # Install ROBOT plugins
 RUN wget -nv -O /tools/sssom-cli https://github.com/gouttegd/sssom-java/releases/download/sssom-java-$SSSOM_JAVA_VERSION/sssom-cli && \

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -104,6 +104,6 @@ RUN wget -nv https://github.com/ontodev/rdftab.rs/archive/refs/tags/v$RDFTAB_VER
     tar xf rdftab.tar.gz && \
     cd rdftab.rs-$RDFTAB_VERSION && \
     cargo build --release -Z sparse-registry && \
-    install -D -m 755 target/release/rdftab /staging/full/usr/bin/rdftab && \
+    install -D -m 755 target/release/rdftab /staging/lite/usr/bin/rdftab && \
     cd /build && \
     rm -rf rdftab.rs-$RDFTAB_VERSION rdftab.tar.gz /root/.cargo

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -5,12 +5,13 @@ ENV ROBOT_VERSION=1.9.7
 ENV DOSDP_VERSION=0.19.3
 ENV OWLTOOLS_VERSION=2020-04-06
 ENV AMMONITE_VERSION=2.5.9
+ENV RELATION_GRAPH=2.3.2
 
 WORKDIR /tools
 ENV JAVA_HOME="/usr"
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-ENV PATH="/tools:/tools/dosdptools/bin:$PATH"
+ENV PATH="/tools:/tools/dosdptools/bin:/tools/relation-graph/bin:$PATH"
 
 ARG ODK_VERSION=0.0.0
 ENV ODK_VERSION=$ODK_VERSION
@@ -33,7 +34,8 @@ RUN apt-get update && \
         jq \
         rsync \
         time \
-        sudo
+        sudo \
+        sqlite3
 
 # Install Python environment (copied over from the builder image).
 COPY --from=obolibrary/odkbuild:latest /staging/lite /
@@ -72,6 +74,12 @@ RUN wget -nv https://github.com/lihaoyi/Ammonite/releases/download/$AMMONITE_VER
         -O /tools/amm && \
     chmod 755 /tools/amm && \
     java -cp /tools/amm ammonite.AmmoniteMain /dev/null
+
+# Install relation-graph
+RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RELATION_GRAPH/relation-graph-cli-$RELATION_GRAPH.tgz && \
+    tar -zxvf relation-graph-cli-$RELATION_GRAPH.tgz && \
+    mv relation-graph-cli-$RELATION_GRAPH /tools/relation-graph && \
+    chmod +x /tools/relation-graph
 
 # Install RDF/XML validation script
 COPY --chmod=755 scripts/check-rdfxml.sh /tools/check-rdfxml

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -698,7 +698,7 @@ class OntologyProject(JsonSchemaMixin):
     """Define which object properties to materialise at release time."""
     
     export_formats : List[str] = field(default_factory=lambda: ['owl', 'obo'])
-    """A list of export formats you wish your release artefacts to be exported to, such as owl, obo, gz, ttl."""
+    """A list of export formats you wish your release artefacts to be exported to, such as owl, obo, gz, ttl, db."""
     
     namespaces : Optional[List[str]] = None
     """A list of namespaces that are considered at home in this ontology. Used for certain filter commands."""

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -697,7 +697,7 @@ class OntologyProject(JsonSchemaMixin):
     release_materialize_object_properties : List[str] = None
     """Define which object properties to materialise at release time."""
     
-    export_formats : List[str] = field(default_factory=lambda: ['owl', 'obo'])
+    export_formats : List[str] = field(default_factory=lambda: ['owl', 'obo', 'db'])
     """A list of export formats you wish your release artefacts to be exported to, such as owl, obo, gz, ttl, db."""
     
     namespaces : Optional[List[str]] = None

--- a/requirements.txt.lite
+++ b/requirements.txt.lite
@@ -14,4 +14,5 @@ tsvalid
 jinjanator
 lightrdf
 sssom
+semsql
 babelon

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -16,6 +16,7 @@ src/ontology/reports/*
 src/ontology/{{ project.id }}.owl
 src/ontology/{{ project.id }}.obo
 src/ontology/{{ project.id }}.json
+src/ontology/{{ project.id }}.db
 src/ontology/{{ project.id }}-base.*
 src/ontology/{{ project.id }}-basic.*
 src/ontology/{{ project.id }}-full.*

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -757,6 +757,10 @@ $(SUBSETDIR)/%.json: $(SUBSETDIR)/%.owl
 	$(ROBOT) convert --input $< --check false -f json -o $@.tmp.json &&\
 	mv $@.tmp.json $@
 {% endif -%}
+{% if 'db' in project.export_formats -%}
+$(SUBSETDIR)/%.db: $(SUBSETDIR)/%.owl
+	semsql make $(SUBSETDIR)/$*.db && rm -f $(SUBSETDIR)/$*-relation-graph.tsv.gz
+{% endif -%}
 
 {% endif %}
 
@@ -1056,6 +1060,10 @@ $(TRANSLATIONSDIR)/%.babelon.json: $(TRANSLATIONSDIR)/%.babelon.tsv
 		convert --check false -f json -o $@.tmp.json &&\
 		mv $@.tmp.json $@
 {% endif -%}
+{% if 'db' in project.export_formats -%}
+{{ release }}.db: {{ release }}.owl
+	semsql make {{ release }}.db && rm -f {{ release }}-relation-graph.tsv.gz
+{% endif -%}
 {% endfor -%}
 
 # ----------------------------------------
@@ -1080,6 +1088,10 @@ $(ONT).json: $(ONT).owl
 	$(ROBOT) annotate --input $< --ontology-iri $(URIBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert --check false -f json -o $@.tmp.json &&\
 		mv $@.tmp.json $@
+{% endif -%}
+{% if 'db' in project.export_formats -%}
+$(ONT).db: $(ONT).owl
+	semsql make $(ONT).db && rm -f $(ONT)-relation-graph.tsv.gz
 {% endif -%}
 
 # -----------------------------------------------------

--- a/tests/test-release-format.yaml
+++ b/tests/test-release-format.yaml
@@ -19,6 +19,7 @@ export_formats:
   - obo
   - json
   - ttl
+  - semsql
 import_group:
   products:
     - id: ro

--- a/tests/test-release-format.yaml
+++ b/tests/test-release-format.yaml
@@ -19,7 +19,7 @@ export_formats:
   - obo
   - json
   - ttl
-  - semsql
+  - db
 import_group:
   products:
     - id: ro


### PR DESCRIPTION
This PR adds `db` as a new export format for release artefacts.

A `.db` file is a SQLite3 file containing a SemSQL representation of the release product.

I would have preferred to use a different name (like `semsql`) for the export name, but currently, the code in the ODK assumes that the _name_ of a format is necessarily the same thing as its _extension_, so it is not possible to declare a format named `semsql` that is supposed to produce files with an extension of `.db`. This is something that we may want to change in the future, but arguably being able to produce SQLite/SemSQL files is more important than being able to name the format the way we would like.

All tools needed to build SQLite3/SemSQL files (`semsql`, `rdftab`, `sqlite3`, and `relation-graph`) are moved from ODKFull to ODKLite, so that the standard, ODK-generated workflows still only require ODKLite. This increases the size of ODKLite from ~1.34GB to ~1.5GB (compared to ~3.06GB for ODKFull).

closes #1142