### PR TITLE
Add SQLite/SemSQL export format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-i
     automake \
     aha \
     dos2unix \
-    sqlite3 \
     libjson-perl \
     libbusiness-isbn-perl \
     pkg-config \
@@ -101,14 +100,6 @@ RUN chmod +x /tools/obodash && \
     echo "build/robot.jar:" >> Makefile && \
     echo "	echo 'skipped ROBOT jar download.....' && touch \$@" >> Makefile && \
     echo "" >> Makefile
-
-# Install relation-graph
-ENV RG=2.3.2
-ENV PATH="/tools/relation-graph/bin:$PATH"
-RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RG/relation-graph-cli-$RG.tgz \
-&& tar -zxvf relation-graph-cli-$RG.tgz \
-&& mv relation-graph-cli-$RG /tools/relation-graph \
-&& chmod +x /tools/relation-graph
 
 # Install ROBOT plugins
 RUN wget -nv -O /tools/sssom-cli https://github.com/gouttegd/sssom-java/releases/download/sssom-java-$SSSOM_JAVA_VERSION/sssom-cli && \

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -104,6 +104,6 @@ RUN wget -nv https://github.com/ontodev/rdftab.rs/archive/refs/tags/v$RDFTAB_VER
     tar xf rdftab.tar.gz && \
     cd rdftab.rs-$RDFTAB_VERSION && \
     cargo build --release -Z sparse-registry && \
-    install -D -m 755 target/release/rdftab /staging/full/usr/bin/rdftab && \
+    install -D -m 755 target/release/rdftab /staging/lite/usr/bin/rdftab && \
     cd /build && \
     rm -rf rdftab.rs-$RDFTAB_VERSION rdftab.tar.gz /root/.cargo

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -5,12 +5,13 @@ ENV ROBOT_VERSION=1.9.7
 ENV DOSDP_VERSION=0.19.3
 ENV OWLTOOLS_VERSION=2020-04-06
 ENV AMMONITE_VERSION=2.5.9
+ENV RELATION_GRAPH=2.3.2
 
 WORKDIR /tools
 ENV JAVA_HOME="/usr"
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-ENV PATH="/tools:/tools/dosdptools/bin:$PATH"
+ENV PATH="/tools:/tools/dosdptools/bin:/tools/relation-graph/bin:$PATH"
 
 ARG ODK_VERSION=0.0.0
 ENV ODK_VERSION=$ODK_VERSION
@@ -33,7 +34,8 @@ RUN apt-get update && \
         jq \
         rsync \
         time \
-        sudo
+        sudo \
+        sqlite3
 
 # Install Python environment (copied over from the builder image).
 COPY --from=obolibrary/odkbuild:latest /staging/lite /
@@ -72,6 +74,12 @@ RUN wget -nv https://github.com/lihaoyi/Ammonite/releases/download/$AMMONITE_VER
         -O /tools/amm && \
     chmod 755 /tools/amm && \
     java -cp /tools/amm ammonite.AmmoniteMain /dev/null
+
+# Install relation-graph
+RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RELATION_GRAPH/relation-graph-cli-$RELATION_GRAPH.tgz && \
+    tar -zxvf relation-graph-cli-$RELATION_GRAPH.tgz && \
+    mv relation-graph-cli-$RELATION_GRAPH /tools/relation-graph && \
+    chmod +x /tools/relation-graph
 
 # Install RDF/XML validation script
 COPY --chmod=755 scripts/check-rdfxml.sh /tools/check-rdfxml

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -84,6 +84,9 @@ RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RELAT
 # Install RDF/XML validation script
 COPY --chmod=755 scripts/check-rdfxml.sh /tools/check-rdfxml
 
+# Install script to convert JSON context prefix map to CSV prefix map
+COPY --chmod=755 scripts/context2csv.py /tools/context2csv
+
 # Make sure we run under an existing user account with UID/GID
 # matching the UID/GID of the calling user
 COPY --chmod=755 scripts/entrypoint.sh /usr/local/sbin/odkuser-entrypoint.sh

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -698,7 +698,7 @@ class OntologyProject(JsonSchemaMixin):
     """Define which object properties to materialise at release time."""
     
     export_formats : List[str] = field(default_factory=lambda: ['owl', 'obo'])
-    """A list of export formats you wish your release artefacts to be exported to, such as owl, obo, gz, ttl."""
+    """A list of export formats you wish your release artefacts to be exported to, such as owl, obo, gz, ttl, db."""
     
     namespaces : Optional[List[str]] = None
     """A list of namespaces that are considered at home in this ontology. Used for certain filter commands."""

--- a/requirements.txt.lite
+++ b/requirements.txt.lite
@@ -14,4 +14,5 @@ tsvalid
 jinjanator
 lightrdf
 sssom
+semsql
 babelon

--- a/scripts/context2csv.py
+++ b/scripts/context2csv.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+try:
+    context = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit("Cannot read context file")
+
+if not '@context' in context:
+    sys.exit("No @context in supposed context file")
+
+print("prefix,base")
+for prefix_name, url_prefix in context['@context'].items():
+    print(f"{prefix_name},{url_prefix}")

--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -6,6 +6,8 @@ bin/
 *.tmp.obo
 *.tmp.owl
 *.tmp.json
+*-relation-graph.tsv.gz
+.template.db
 
 .github/token.txt
 
@@ -16,11 +18,13 @@ src/ontology/reports/*
 src/ontology/{{ project.id }}.owl
 src/ontology/{{ project.id }}.obo
 src/ontology/{{ project.id }}.json
+src/ontology/{{ project.id }}.db
 src/ontology/{{ project.id }}-base.*
 src/ontology/{{ project.id }}-basic.*
 src/ontology/{{ project.id }}-full.*
 src/ontology/{{ project.id }}-simple.*
 src/ontology/{{ project.id }}-simple-non-classified.*
+src/ontology/config/context.csv
 
 src/ontology/seed.txt
 src/ontology/dosdp-tools.log

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -73,6 +73,9 @@ ONTOLOGYTERMS =             $(TMPDIR)/ontologyterms.txt
 EDIT_PREPROCESSED =         $(TMPDIR)/$(ONT)-preprocess.owl
 {%- if project.use_context %}
 CONTEXT_FILE =              config/context.json
+{%- if 'db' in project.export_formats %}
+CONTEXT_FILE_CSV =          config/context.csv
+{%- endif %}
 {%- endif %}
 
 {%- if project.use_dosdps %}
@@ -1057,6 +1060,19 @@ $(TRANSLATIONSDIR)/%.babelon.json: $(TRANSLATIONSDIR)/%.babelon.tsv
 		mv $@.tmp.json $@
 {% endif -%}
 {% endfor -%}
+
+{% if 'db' in project.export_formats -%}
+{% if project.use_context -%}
+$(CONTEXT_FILE_CSV): $(CONTEXT_FILE)
+	context2csv < $< > $@
+{% endif -%}
+
+%.db: %.owl $(CONTEXT_FILE_CSV)
+	@rm -f $*.db $*-relation-graph.tsv.gz .template.db .template.db.tmp
+	semsql make $*.db{% if project.use_context %} -P $(CONTEXT_FILE_CSV){% endif %}
+	@rm -f $*-relation-graph.tsv.gz .template.db .template.db.tmp
+	@test -f $*.db || (echo "SQLite/SemSQL generation failed" && exit 1)
+{% endif -%}
 
 # ----------------------------------------
 # Release artefacts: main release artefacts

--- a/tests/test-release-format.yaml
+++ b/tests/test-release-format.yaml
@@ -19,6 +19,7 @@ export_formats:
   - obo
   - json
   - ttl
+  - db
 import_group:
   products:
     - id: ro


### PR DESCRIPTION
(This is exactly the same PR as #1147, just without the last commit which enabled SQLite/SemSQL export by default on all repos.)

This PR adds `db` as a new export format for release artefacts.

A `.db` file is a SQLite3 file containing a SemSQL representation of the release product.

All tools needed to build SQLite3/SemSQL files (`semsql`, `rdftab`, `sqlite3`, and `relation-graph`) are moved from ODKFull to ODKLite, so that the standard, ODK-generated workflows still only require ODKLite. This increases the size of ODKLite from ~1.34GB to ~1.5GB (compared to ~3.06GB for ODKFull).

If the project is configured to use a global prefix context (`use_context=true`), the same context (converted from JSON to CSV) is used when building the SemSQL files. Otherwise, we let `semsql` use its built-in list of prefixes.

closes #1142