### PR TITLE
Fix location of generated context.json file.

### DIFF
--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -24,7 +24,6 @@ src/ontology/{{ project.id }}-basic.*
 src/ontology/{{ project.id }}-full.*
 src/ontology/{{ project.id }}-simple.*
 src/ontology/{{ project.id }}-simple-non-classified.*
-src/ontology/config/context.csv
 
 src/ontology/seed.txt
 src/ontology/dosdp-tools.log

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -476,7 +476,7 @@ Documentation of the Default DOSDP Pipeline
 {%- endif %}
 {%- endif %}
 {%- if project.use_context %}
-^^^ config/context.json
+^^^ src/ontology/config/context.json
 {
 	"@context": {
 		"obo": "http://purl.obolibrary.org/obo/",

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -74,7 +74,7 @@ EDIT_PREPROCESSED =         $(TMPDIR)/$(ONT)-preprocess.owl
 {%- if project.use_context %}
 CONTEXT_FILE =              config/context.json
 {%- if 'db' in project.export_formats %}
-CONTEXT_FILE_CSV =          config/context.csv
+CONTEXT_FILE_CSV =          $(TMPDIR)/context.csv
 {%- endif %}
 {%- endif %}
 
@@ -1063,7 +1063,7 @@ $(TRANSLATIONSDIR)/%.babelon.json: $(TRANSLATIONSDIR)/%.babelon.tsv
 
 {% if 'db' in project.export_formats -%}
 {% if project.use_context -%}
-$(CONTEXT_FILE_CSV): $(CONTEXT_FILE)
+$(CONTEXT_FILE_CSV): $(CONTEXT_FILE) | $(TMPDIR)
 	context2csv < $< > $@
 {% endif -%}
 

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1067,7 +1067,7 @@ $(CONTEXT_FILE_CSV): $(CONTEXT_FILE) | $(TMPDIR)
 	context2csv < $< > $@
 {% endif -%}
 
-%.db: %.owl $(CONTEXT_FILE_CSV)
+%.db: %.owl{% if project.use_context %} $(CONTEXT_FILE_CSV){% endif %}
 	@rm -f $*.db $*-relation-graph.tsv.gz .template.db .template.db.tmp
 	semsql make $*.db{% if project.use_context %} -P $(CONTEXT_FILE_CSV){% endif %}
 	@rm -f $*-relation-graph.tsv.gz .template.db .template.db.tmp


### PR DESCRIPTION
This PR ensures that, when seeding, if the project is configured to use a context, the initial context file is created in `src/ontology/config`, where the Makefile expects to find it.

While we are at it, and related, we fix two small issues with the #1148 PR:

* The `context.csv` file is a file that is _derived_ from the `context.json` file; as such, it should be written into the `tmp` directory, rather than into the `config` directory. Having such a file in `config` could lead users to think they can (or are even expected to) edit that file, while they are only supposed to edit the `context.json` file.

* The target to create a SQLite file should depend on the CSV context file _only_ when the project is configured to use a context.