### PR TITLE
Update SSSOM-Java to version 1.0.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV ODK_VERSION=$ODK_VERSION
 # Software versions
 ENV JENA_VERSION=4.9.0
 ENV KGCL_JAVA_VERSION=0.5.0
-ENV SSSOM_JAVA_VERSION=0.9.0
+ENV SSSOM_JAVA_VERSION=1.0.0
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:
 # docker run -v $HOME/.coursier/cache/v1:/tools/.coursier-cache ...


### PR DESCRIPTION
This PR updates the version of SSSOM-Java bundled with the ODK to the latest 1.0.0 version.