### PR TITLE
Make sure SPARQL checks cover the entire ontology.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ For more detailed changes see:
 ## Bugfixes
 
 - Added back `class-count-by-prefix.sparql` ([#1030](https://github.com/INCATools/ontology-development-kit/issues/1030)).
-- Disabled `table-reader` mkdocs plygin ([#1028](https://github.com/INCATools/ontology-development-kit/issues/1028)).
+- Disabled `table-reader` mkdocs plugin ([#1028](https://github.com/INCATools/ontology-development-kit/issues/1028)).
 - SPARQL-based tests on the `-edit` file now also cover any component included in the ontology, as well as any pattern-derived contents ([#1154](https://github.com/INCATools/ontology-development-kit/issues/1154)).
 
 # v1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ For more detailed changes see:
 
 ## Bugfixes
 
-- Added back `class-count-by-prefix.sparql` ([https://github.com/INCATools/ontology-development-kit/issues/1030](#1030))
-- Disabled `table-reader` mkdocs plygin ([https://github.com/INCATools/ontology-development-kit/issues/1028](#1028))
+- Added back `class-count-by-prefix.sparql` ([#1030](https://github.com/INCATools/ontology-development-kit/issues/1030)).
+- Disabled `table-reader` mkdocs plygin ([#1028](https://github.com/INCATools/ontology-development-kit/issues/1028)).
+- SPARQL-based tests on the `-edit` file now also cover any component included in the ontology, as well as any pattern-derived contents ([#1154](https://github.com/INCATools/ontology-development-kit/issues/1154)).
 
 # v1.5
 

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -298,11 +298,11 @@ validate_profile_%: $(REPORTDIR)/validate_profile_owl2dl_%.txt
 
 SPARQL_VALIDATION_QUERIES = $(foreach V,$(SPARQL_VALIDATION_CHECKS),$(SPARQLDIR)/$(V)-violation.sparql)
 
-sparql_test: {% for x in project.robot_report.sparql_test_on|default(["edit"]) %} {% if x=="edit" %}$(EDIT_PREPROCESSED){% else %}{{ x }}{% endif %}{% endfor %} | $(REPORTDIR)
+sparql_test: {% for x in project.robot_report.sparql_test_on|default(["edit"]) %} {% if x=="edit" %}$(SRCMERGED){% else %}{{ x }}{% endif %}{% endfor %} | $(REPORTDIR)
 ifneq ($(SPARQL_VALIDATION_QUERIES),)
   {% for x in project.robot_report.sparql_test_on|default(["edit"]) -%}
   {%- if x=="edit" -%}
-  {% set input = "$(EDIT_PREPROCESSED)"%}
+  {% set input = "$(SRCMERGED)"%}
   {%- else -%}
   {% set input = x %}
   {% endif %}


### PR DESCRIPTION
ROBOT's `verify` command does not follow OWL Import declarations, so the checks it performs only applies strictly to the file it is given as input.

Components and pattern-derived definitions are part of the "local" ontology and should be covered by the SPARQL checks, and we ensure they are by running the `verify` command on the `$(SRCMERGED)` intermediate file, in which components and pattern-derived definitions (basically all files listed in $(OTHER_SRC)`) are explicitly merged (but _not_ ODK imports).

closes #1154