### PR TITLE
Fix NPM-installed files with large UID/GID.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,8 @@ RUN wget -nv http://archive.apache.org/dist/jena/binaries/apache-jena-$JENA_VERS
 RUN swipl -g "pack_install(sparqlprog, [interactive(false),global(true)])" -g halt
 
 # Install obographviz
-RUN npm install -g obographviz
+RUN npm install -g obographviz && \
+    chown -R root:root /usr/local/lib/node_modules
 
 # Install OBO-Dashboard.
 COPY scripts/obodash /tools


### PR DESCRIPTION
For some unknown reasons (*cough* Javascript *cough*), when NPM's `underscore` module is installed (as a dependency to Obographviz), its files are given some impossibly large UID and GID. This may prevent the final image from being used on systems where Docker runs in rootless mode.

So after Obographviz is installed, we ensure that all files and directories under /usr/local/lib/node_modules belong to root as they should.

closes #1156