### PR TITLE
Make Ammonite cache its files in TMPDIR.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1333,8 +1333,8 @@ normalize_src: $(SRC)
 	$(ROBOT) convert -i $< -f {% if 'obo' == project.edit_format %}obo --check false{% else %}ofn{% endif %} -o $(TMPDIR)/normalise && mv $(TMPDIR)/normalise $<
 
 .PHONY: validate_idranges
-validate_idranges:
-	amm $(SCRIPTSDIR)/validate_id_ranges.sc {{ project.id }}-idranges.owl
+validate_idranges: | $(TMPDIR)
+	COURSIER_CACHE=$(TMPDIR)/coursier-cache amm $(SCRIPTSDIR)/validate_id_ranges.sc {{ project.id }}-idranges.owl
 
 .PHONY: update_repo
 update_repo:


### PR DESCRIPTION
When running a Scala script, Ammonite attempts to download and store the script's dependencies in `/tools/.coursier-cache`, which requires root privileges.

We force Ammonite to write its cache in the current ontology's `TMPDIR` instead.

closes #1159