### PR TITLE
Update some ODK programs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ ARG ODK_VERSION 0.0.0
 ENV ODK_VERSION=$ODK_VERSION
 
 # Software versions
+# Jena 5.x requires Java 17, so for now we are stuck with Jena 4.x
 ENV JENA_VERSION=4.9.0
-ENV KGCL_JAVA_VERSION=0.5.0
-ENV SSSOM_JAVA_VERSION=1.0.0
+ENV KGCL_JAVA_VERSION=0.5.1
+ENV SSSOM_JAVA_VERSION=1.1.1
 ENV AMMONITE_VERSION=2.5.9
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /build
 
 # Software versions
 ENV RDFTAB_VERSION=0.1.1
-ENV SOUFFLE_VERSION=2.4
+ENV SOUFFLE_VERSION=2.4.1
 ENV FASTOBO_VALIDATOR_VERSION=0.4.6
 
 # Everything that we want to get into one of the final ODK images


### PR DESCRIPTION
Update some of the programs bundled with the ODK:

* Soufflé to version 2.4.1;
* KGCL-Java to version 0.5.1;
* SSSOM-Java to version 1.1.1.

Also add a note to remind us that we *cannot* update Jena to version 5, as that version requires Java >= 17 and the ODK base image still provides Java 11 for now.

There is a 3.0.0 version of Ammonite since september 2024, but we do not upgrade it for now because (1) I don't know or use Ammonite enough (at all, actually) to know whether the new major version is likely to break any existing custom workflow that requires Ammonite, and (2) Jim Balhoff is keen to migrate from Ammonite to Scala-CLI anyway (#1162).