### PR TITLE
Add Scala-CLI, but do not remove Ammonite yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For more detailed changes see:
 - New [ROBOT Version 1.9.6](https://github.com/ontodev/robot/releases/tag/v1.9.6). This came with a great number of updates and upgrades, see release notes.
 - J2cli, a command-line tool to process Jinja2 templates, has been replaced by [Jinjanator](https://github.com/kpfleming/jinjanator). If your custom workflows invoke the `j2` tool, you will need to update them to use `jinjanate` instead.
 - New program `dicer-cli` to manage the ID range file.
-- Ammonite, the Scala interpreter, is no longer provided in the ODKLite image. If you need Ammonite, you must now use the ODKFull image.
+- Ammonite, the Scala interpreter, is no longer provided in the ODKLite image. If you need Ammonite, you must now use the ODKFull image. Be warned that Ammonite is slated for complete removal in a future ODK release, you should use Scala-CLI instead.
 - The Scala-CLI Scala runner has been added to the ODKFull image.
 
 ## New configuration options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For more detailed changes see:
 - J2cli, a command-line tool to process Jinja2 templates, has been replaced by [Jinjanator](https://github.com/kpfleming/jinjanator). If your custom workflows invoke the `j2` tool, you will need to update them to use `jinjanate` instead.
 - New program `dicer-cli` to manage the ID range file.
 - Ammonite, the Scala interpreter, is no longer provided in the ODKLite image. If you need Ammonite, you must now use the ODKFull image.
+- The Scala-CLI Scala runner has been added to the ODKFull image.
 
 ## New configuration options
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV JENA_VERSION=4.9.0
 ENV KGCL_JAVA_VERSION=0.5.1
 ENV SSSOM_JAVA_VERSION=1.1.1
 ENV AMMONITE_VERSION=2.5.9
+ENV SCALA_CLI_VERSION=1.5.4
 
 # Avoid repeated downloads of script dependencies by mounting the local coursier cache:
 # docker run -v $HOME/.coursier/cache/v1:/tools/.coursier-cache ...
@@ -91,6 +92,13 @@ RUN wget -nv https://github.com/lihaoyi/Ammonite/releases/download/$AMMONITE_VER
         -O /tools/amm && \
     chmod 755 /tools/amm && \
     java -cp /tools/amm ammonite.AmmoniteMain /dev/null
+
+# Install Scala-CLI
+RUN wget -nv https://github.com/VirtusLab/scala-cli/releases/download/v$SCALA_CLI_VERSION/scala-cli.jar \
+        -O /tools/scala-cli.jar && \
+    echo "#!/bin/bash" > /tools/scala-cli && \
+    echo "java -jar /tools/scala-cli.jar \"\$@\"" >> /tools/scala-cli && \
+    chmod 0755 /tools/scala-cli
 
 # Install SPARQLProg.
 RUN swipl -g "pack_install(sparqlprog, [interactive(false),global(true)])" -g halt

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ test_odkfull_programs: test_odklite_programs
 	@./tests/test-program.sh SOUFFLE souffle --version
 	@./tests/test-program.sh JENA jena
 	@./tests/test-program.sh AMMONITE sh amm --help
+	@./tests/test-program.sh SCALA-CLI scala-cli --version
 	@./tests/test-program.sh SPARQL sparql --version
 	@./tests/test-program.sh SPARQLPROG pl2sparql -g halt
 	@./tests/test-program.sh OBO-DASHBOARD obodash --help

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,6 +13,10 @@ mkdir -p /home/odkuser
 chown odkuser:odkuser /home/odkuser
 [ -d /home/odkuser/.data ] && chown odkuser:odkuser /home/odkuser/.data
 [ -d /home/odkuser/.data/oaklib ] && chown odkuser:odkuser /home/odkuser/.data/oaklib
+if [ ! -d /tools/.coursier-cache ] ; then
+    mkdir /tools/.coursier-cache
+    chown odkuser:odkuser /tools/.coursier-cache
+fi
 PATH=$PATH:/home/odkuser/.local/bin
 [ -S /run/host-services/ssh-auth.sock ] && chown odkuser /run/host-services/ssh-auth.sock
 


### PR DESCRIPTION
This PR supersedes #1165. It also adds Scala-CLI to ODKFull, but leaves Ammonite in place, with a deprecation notice warning users of its future complete removal (probably in ODK 1.7).

fixes #1161
partially addresses #1162