### PR TITLE
Strip carriage returns when computing config hash at check time.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -169,7 +169,7 @@ odkversion:
 {%- if project.config_hash %}
 .PHONY: config_check
 config_check:
-	@if [ "$$(sha256sum $(ONT)-odk.yaml | cut -c1-64)" = "$(CONFIG_HASH)" ]; then \
+	@if [ "$$(tr -d '\r' < $(ONT)-odk.yaml | sha256sum | cut -c1-64)" = "$(CONFIG_HASH)" ]; then \
 		echo "Repository is up-to-date." ; else \
 		echo "Your ODK configuration has changed since this Makefile was generated. You may need to run 'make update_repo'." ; fi
 {% endif %}


### PR DESCRIPTION
At seeding time, the hash of the configuration file is computed using Python code. The default behaviour of Python, when reading text files, is to automatically translate CRLF line endings (such as those found in text files originating from a Windows machine) into LF line endings (normal line endings from the civilised world). This means that the config hash is computed on a buffer that only contain LF line endings, not CRLF line endings.

But at checking time, the hash of the configuration file is computed using sha256sum, which takes the contents of the file as it is, without any kind of mangling of the line endings.

On GNU/Linux and macOS, this all works fine, because the configuration file only contains LF endings on those systems.

But on Windows, the default behaviour of Git, when checking out a repository, is to write text files with CRLF line endings, therefore causing the configuration file to have a sha256sum-computed hash that is different from the Python-computed hash, and thus causing spurious warnings from the ODK that the configuration file has changed since the Makefile was last re-generated.

The fix is to forcefully strip all carriage returns (CR) from the configuration file prior to computing its hash.

closes #1170