### PR TITLE
Move the pattern_clean rule out of the PAT=true block.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -804,21 +804,19 @@ endif
 # DOSDP Templates/Patterns
 # ----------------------------------------
 
-ifeq ($(PAT),true)
-
 ALL_PATTERN_FILES=$(wildcard $(PATTERNDIR)/dosdp-patterns/*.yaml)
 ALL_PATTERN_NAMES=$(strip $(patsubst %.yaml,%, $(notdir $(wildcard $(PATTERNDIR)/dosdp-patterns/*.yaml))))
 
 PATTERN_CLEAN_FILES=../patterns/all_pattern_terms.txt \
-	$(DOSDP_OWL_FILES_DEFAULT) $(DOSDP_TERM_FILES_DEFAULT) \{% if project.pattern_pipelines_group is defined %}
-	{% for pipeline in project.pattern_pipelines_group.products -%}
-		$(DOSDP_OWL_FILES_{{ pipeline.id.upper() }}) $(DOSDP_TERM_FILES_{{ pipeline.id.upper() }}) {% endfor %}{% endif %}
+	$(DOSDP_OWL_FILES_DEFAULT) $(DOSDP_TERM_FILES_DEFAULT){% if project.pattern_pipelines_group is defined  -%}
+	{% for pipeline in project.pattern_pipelines_group.products %} \
+	$(DOSDP_OWL_FILES_{{ pipeline.id.upper() }}) $(DOSDP_TERM_FILES_{{ pipeline.id.upper() }}){% endfor %}{% endif %}
 
-# Note to future generations: prepending ./ is a safety measure to ensure that 
-# the environment does not malicously set `PATTERN_CLEAN_FILES` to `\`.
 .PHONY: pattern_clean
 pattern_clean:
 	rm -f $(PATTERN_CLEAN_FILES)
+
+ifeq ($(PAT),true)
 
 .PHONY: patterns
 patterns dosdp:


### PR DESCRIPTION
This PR makes sure that the `pattern_clean` rule is always defined, even when PAT is set to false. This is because that rule is explicitly called by the general `clean` rule.

Of note, under PAT=false, `pattern_clean` can be called but it will not clean _all_ the pattern-derived files, because the variables defining the list of files to clean are themselves defined within the PAT block, and moving them out of the block would be too much of a hassle for little benefits.

While we are at it, this commit also removes an obsolete comment about the prepending of `./` to prevent deleting files outside of the repository, and clears some superfluous whitespaces.

closes #1176