### PR TITLE
Check the ID range file when running the tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ For more detailed changes see:
 
 ## Makefile workflows
 
-- TBD
+- The `$(ont)-idranges.owl` file is now checked for validity as part of the normal test suite [#211](https://github.com/INCATools/ontology-development-kit/issues/211).
 
 ## Runner and Infrastructure
 

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -144,7 +144,7 @@ all: all_odk
 all_odk: odkversion{% if project.config_hash %} config_check{% endif %} test custom_reports all_assets{% if project.release_diff %} release_diff{% endif %}
 
 .PHONY: test
-test: odkversion {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot_report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
+test: odkversion validate_idranges {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot_report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
 	echo "Finished running all tests successfully."
 
 .PHONY: test


### PR DESCRIPTION
This PR makes `validate_idranges` a dependency of the `test` target, so the ID range file is systematically checked for errors as part of the standard test suite.

closes #211