### PR TITLE
Use `robot export` to generate subset TSV files.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -785,7 +785,8 @@ endif # MIR=true
 # Subsets
 # ----------------------------------------
 $(SUBSETDIR)/%.tsv: $(SUBSETDIR)/%.owl
-	$(ROBOT) query -f tsv -i $< -s ../sparql/labels.sparql $@
+	$(ROBOT) export -i $< --include classes \
+		        --header "ID [IRI]|LABEL" --format tsv --export $@
 .PRECIOUS: $(SUBSETDIR)/%.tsv
 
 $(SUBSETDIR)/%.owl: $(ONT).owl | $(SUBSETDIR) all_robot_plugins

--- a/template/src/sparql/labels.sparql
+++ b/template/src/sparql/labels.sparql
@@ -1,9 +1,0 @@
-PREFIX owl: <http://www.w3.org/2002/07/owl#>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-
-SELECT ?x (STR(?lab) AS ?label) WHERE {
-	?x rdf:type owl:Class .
-	OPTIONAL {?x rdfs:label ?lab}
-}
-ORDER BY ?x


### PR DESCRIPTION
For every subset, we produce a TSV file that is supposed to list the classes in the subset. This is done by a SPARQL query.

However, this can be done much more efficiently with a `robot export` command, which is what we do here. On some ontologies that I have tested (Uberon, CL), this is about 2 to 3 times faster.

This also automatically excludes blank nodes from the listing, contrary to the original SPARQL query.

closes #798