### PR TITLE
Put the current ROBOT profile in the templates directory.

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -46,8 +46,9 @@ RUN wget -nv $ROBOT_JAR \
     wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/bin/robot \
         -O /tools/robot && \
     chmod 755 /tools/robot &&\
+    mkdir -p /tools/templates/src/ontology &&\
     wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/robot-core/src/main/resources/report_profile.txt \
-        -O /tools/robot_report_profile.txt
+        -O /tools/templates/src/ontology/profile.txt
 
 # Install DOSDPTOOLS.
 RUN wget -nv https://github.com/INCATools/dosdp-tools/releases/download/v$DOSDP_VERSION/dosdp-tools-$DOSDP_VERSION.tgz && \

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -1117,6 +1117,8 @@ def update(templatedir):
                 policies.append(('.github/workflows/' + workflow + '.yml', ALWAYS))
         if project.documentation is not None and 'docs' in project.workflows:
             policies.append(('.github/workflows/docs.yml', ALWAYS))
+    if not project.robot_report.get('custom_profile', False):
+        policies.append(('src/ontology/profile.txt', NEVER))
 
     # Proceed with template instantiation, using the policies
     # declared above. We instantiate directly at the root of
@@ -1190,7 +1192,10 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
     if not os.path.exists(templatedir) and templatedir == "/tools/templates/":
         logging.info("No templates folder in /tools/; assume not in docker context")
         templatedir = "./template"
-    tgts += install_template_files(mg, templatedir, outdir)
+    policies = []
+    if not project.robot_report.get('custom_profile', False):
+        policies.append(('src/ontology/profile.txt', NEVER))
+    tgts += install_template_files(mg, templatedir, outdir, policies)
 
     tgt_project_file = "{}/project.yaml".format(outdir)
     if project.export_project_yaml:

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -692,41 +692,6 @@ SELECT ?term ?predicate WHERE {
 </rdf:RDF>
 {%- endfor %}
 {%- endif %}
-{%- if project.robot_report.custom_profile %}
-^^^ src/ontology/profile.txt
-WARN	annotation_whitespace
-ERROR	deprecated_boolean_datatype
-ERROR	deprecated_class_reference
-ERROR	deprecated_property_reference
-ERROR	duplicate_definition
-WARN	duplicate_exact_synonym
-WARN	duplicate_label_synonym
-ERROR	duplicate_label
-WARN	duplicate_scoped_synonym
-WARN	equivalent_pair
-WARN	equivalent_class_axiom_no_genus
-ERROR	illegal_use_of_built_in_vocabulary
-WARN	invalid_xref
-ERROR	label_formatting
-ERROR	label_whitespace
-INFO	lowercase_definition
-WARN	missing_definition
-ERROR	missing_label
-WARN	missing_obsolete_label
-ERROR	missing_ontology_description
-ERROR	missing_ontology_license
-ERROR	missing_ontology_title
-WARN	missing_subset_declaration
-INFO	missing_superclass
-WARN	missing_synonymtype_declaration
-ERROR	misused_obsolete_label
-ERROR	misused_replaced_by
-ERROR	multiple_definitions
-ERROR	multiple_equivalent_classes
-ERROR	multiple_equivalent_class_definitions
-ERROR	multiple_labels
-WARN	invalid_entity_uri
-{%- endif %}
 {%- if 'basic' in project.release_artefacts or project.primary_release == 'basic' %}
 ^^^ src/ontology/keeprelations.txt
 BFO:0000050

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -364,7 +364,7 @@ $(REPORTDIR)/%-align-report.tsv: % | $(REPORTDIR) all_robot_plugins
 
 check_for_robot_updates:
 {%- if project.robot_report.custom_profile %}	
-	@cut -f2 "/tools/robot_report_profile.txt" | sort > $(TMPDIR)/sorted_tsv2.txt
+	@cut -f2 "/tools/templates/src/ontology/profile.txt" | sort > $(TMPDIR)/sorted_tsv2.txt
 	@cut -f2 "$(ROBOT_PROFILE)" | sort > $(TMPDIR)/sorted_tsv1.txt
 	@comm -23 $(TMPDIR)/sorted_tsv2.txt $(TMPDIR)/sorted_tsv1.txt > $(TMPDIR)/missing.txt
 	@echo "Missing tests:"


### PR DESCRIPTION
For now, when building the image, we download the ROBOT report profile for the current version of ROBOT (the version used in the ODK) and put it in `/tools/robot_report_profile.txt`. We do that so that we can check, as part of the standard workflow, whether the custom profile that the project may be using is not lacking any new tests that are available in the current version of ROBOT (see #998).

Here, we simply move the location of the profile file within the image, from `/tools/robot_report_profile.txt` to `/tools/templates/src/ontology/profile.txt`.

This does not change how the check mentioned above works (we just update the path involved in that check), but this will have the benefit of automatically installing the ROBOT profile when seeding a repository, since the file is now within the template directory used by the seeding system.

Therefore, we can remove the `src/ontology/profile.txt` block from the dynamic template pack (which needed to be manually updated by us whenever we updated ROBOT – something I don't think we have really been doing).

But we do not want to _always_ install this `profile.txt` file in a seeded repository – we only need to do that when the use of a custom profile is enabled in the configuration (that was the reason why the profile was part of the dynamic template pack). To avoid installing the file when a custom profile is _not_ enabled, we use the recently introduced per-template policies system: we set the policy for the `src/ontology/profile.txt` template to NEVER if a custom profile is not enabled.

closes #999