### PR TITLE
Do not fail for a missing idranges file.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1386,7 +1386,7 @@ normalize_src: $(SRC)
 
 .PHONY: validate_idranges
 validate_idranges:
-	dicer-cli {{ project.id }}-idranges.owl
+	if [ -f {{ project.id }}-idranges.owl ]; then dicer-cli {{ project.id }}-idranges.owl ; fi
 
 # Deprecated: Use 'sh run.sh odk.py update' without using the Makefile.
 .PHONY: update_repo


### PR DESCRIPTION
We now check the validity of the -idranges.owl file as part of the routine QC checks.

But a project may very well decide that they do _not_ need such a file (if they have their own way of allocating IDs), and in that case they may prefer to remove the file that was generated by the ODK seeding process rather than keeping a useless file around.

The absence of an ID range file should not cause a QC failure. If the file is present, then it must be valid, but its absence can be silently ignored.