### PR TITLE
Call temporary script with /bin/sh.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -20,7 +20,7 @@ case "$@" in
     # during the update process
     mkdir -p tmp
     sed -n '/^set -e/,$p' $0 > tmp/$0
-    exec $SHELL tmp/$0 "$@"
+    exec /bin/sh tmp/$0 "$@"
     ;;
 esac
 


### PR DESCRIPTION
The idea behind using `$SHELL` when calling the temporary run.sh script (when running an update_repo command) was to make sure the temporary script is executed using the *same shell* as the one that is currently running the original run.sh script.

But it turns out, that is not reliable. The `$SHELL` variable _may_ be set to the full pathname of the currently running shell, but not always -- it may also be set to the _login shell_ of the current user, which may very well be different from the shell used to call the run.sh script.

So let's always use `/bin/sh` instead. It is guaranteed to always be there, and that is already the shell that should be used to run the run.sh script (that's the shell set in the script's shebang line).

closes #1202