### PR TITLE
Make the stripping of annotation properties optional

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -359,6 +359,9 @@ class ImportGroup(ProductGroup):
     
     annotation_properties : List[str] = field(default_factory=lambda: ['rdfs:label', 'IAO:0000115'])
     """Define which annotation properties to pull in."""
+
+    strip_annotation_properties: bool = True
+    """If set to true, strip away annotation properties from imports, apart from explicitly imported properties and properties listed in annotation_properties."""
     
     directory : Directory = "imports/"
     """directory where imports are extracted into to"""

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -147,7 +147,7 @@ class ImportProduct(Product):
     module_type_slme : str = "BOT"
     """SLME module type. Supported: BOT, TOP, STAR"""
     
-    annotation_properties : List[str] = field(default_factory=lambda: ['rdfs:label', 'IAO:0000115'])
+    annotation_properties : List[str] = field(default_factory=lambda: ['rdfs:label', 'IAO:0000115', 'OMO:0002000'])
     """Define which annotation properties to pull in."""
     
     slme_individuals : str = "include"
@@ -357,7 +357,7 @@ class ImportGroup(ProductGroup):
     export_obo: bool = False
     """If set to true, modules will not only be created in OWL, but also OBO format"""
     
-    annotation_properties : List[str] = field(default_factory=lambda: ['rdfs:label', 'IAO:0000115'])
+    annotation_properties : List[str] = field(default_factory=lambda: ['rdfs:label', 'IAO:0000115', 'OMO:0002000'])
     """Define which annotation properties to pull in."""
 
     strip_annotation_properties: bool = True

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -506,8 +506,10 @@ T_IMPORTSEED = --term-file $(IMPORTSEED)
 {% endif -%}
 
 {% if project.import_group is defined -%}
+{% if project.import_group.strip_annotation_properties -%}
 ANNOTATION_PROPERTIES={% for p in project.import_group.annotation_properties %}{{ p }} {% endfor %}
 
+{% endif -%}
 # ----------------------------------------
 # Import modules
 # ----------------------------------------
@@ -529,10 +531,10 @@ $(IMPORTDIR)/merged_import.owl: $(MIRRORDIR)/merged.owl $(ALL_TERMS) \
 		 extract $(foreach f, $(ALL_TERMS), --term-file $(f)) $(T_IMPORTSEED) \
 		         --force true --copy-ontology-annotations false \
 		         --individuals {{ project.import_group.slme_individuals }} \
-		         --method {{ project.import_group.module_type_slme }} \
+		         --method {{ project.import_group.module_type_slme }} \{% if project.import_group.strip_annotation_properties %}
 		 remove $(foreach p, $(ANNOTATION_PROPERTIES), --term $(p)) \
 		        $(foreach f, $(ALL_TERMS), --term-file $(f)) $(T_IMPORTSEED) \
-		        --select complement --select annotation-properties \
+		        --select complement --select annotation-properties \{% endif %}
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
 		               --merge-axioms true \
@@ -557,7 +559,10 @@ $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 		 extract --term-file $(IMPORTDIR)/$*_terms.txt $(T_IMPORTSEED) \
 		         --force true --copy-ontology-annotations true \
 		         --individuals {{ project.import_group.slme_individuals }} \
-		         --method {{ project.import_group.module_type_slme }} \
+		         --method {{ project.import_group.module_type_slme }} \{% if project.import_group.strip_annotation_properties %}
+		 remove $(foreach p, $(ANNOTATION_PROPERTIES), --term $(p)) \
+		        --term-file $(IMPORTDIR)/$*_terms.txt $(T_IMPORTSEED) \
+		        --select complement --select annotation-properties \{% endif %}
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
 		               --merge-axioms true \
@@ -637,7 +642,11 @@ $(IMPORTDIR)/{{ ont.id }}_import.owl: $(MIRRORDIR)/{{ ont.id }}.owl $(IMPORTDIR)
 		 extract --term-file $(IMPORTDIR)/{{ ont.id }}_terms.txt $(T_IMPORTSEED) \
 		         --copy-ontology-annotations true --force true \
 		         --individuals {{ ont.slme_individuals }} \
-		         --method {{ ont.module_type_slme }} \
+		         --method {{ ont.module_type_slme }} \{% if project.import_group.strip_annotation_properties %}
+		 remove $(foreach p, $(ANNOTATION_PROPERTIES), --term $(p)) \{% for p in ont.annotation_properties %}
+		        --term {{ p }} \{% endfor %}
+		        --term-file $(IMPORTDIR)/{{ ont.id }}_terms.txt $(T_IMPORTSEED) \
+		        --select complement --select annotation-properties \{% endif %}
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
 		               --merge-axioms true \


### PR DESCRIPTION
This PR adds a new option to the ImportGroup section, `strip_annotation_properties`. It allows to disable the stripping of annotation properties from the import modules (introduced in ODK 1.5). The option is enabled by default, preserving the ODK 1.5 behaviour.

It also makes sure that, when annotation stripping is enabled, it is performed on individual SLME modules as well, instead of only on the merged module and individual “filter” and ”“minimal” modules.

Lastly, it adds OMO:0002000 (the property used to define macros expanded by ROBOT’s `expand` command) to the list of properties preserved by default.

closes #1093