### PR TITLE
Improvements to the SSSOM workflows

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -518,6 +518,9 @@ class SSSOMMappingSetGroup(JsonSchemaMixin):
 
     release_mappings : bool = False
     """If set to True, mappings are copied to the release directory."""
+
+    mapping_extractor : str = "sssom-py"
+    """The tool to use to extract mappings from an ontology ('sssom-py' or 'robot')."""
     
     products : Optional[List[SSSOMMappingSetProduct]] = None
 

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -531,15 +531,19 @@ class SSSOMMappingSetGroup(JsonSchemaMixin):
         if len(released_products) > 0:
             self.released_products = released_products
 
-        for product in [p for p in self.products if p.maintenance == "merged"]:
-            if product.source_mappings is None:
-                # Merge all other non-merge sets to make this one
-                product.source_mappings = [p.id for p in self.products if p.maintenance != "merged"]
-            else:
-                # Check that all listed source sets exist
-                for source in product.source_mappings:
-                    if source not in [p.id for p in self.products]:
-                        raise Exception(f"Unknown source mapping set '{source}'")
+        for product in self.products:
+            if product.maintenance == "merged":
+                if product.source_mappings is None:
+                    # Merge all other non-merge sets to make this one
+                    product.source_mappings = [p.id for p in self.products if p.maintenance != "merged"]
+                else:
+                    # Check that all listed source sets exist
+                    for source in product.source_mappings:
+                        if source not in [p.id for p in self.products]:
+                            raise Exception(f"Unknown source mapping set '{source}'")
+            elif product.maintenance == "extract":
+                if product.source_file is None:
+                    product.source_file = "$(EDIT_PREPROCESSED)"
 
 @dataclass_json
 @dataclass

--- a/template/_dynamic_files.jinja2
+++ b/template/_dynamic_files.jinja2
@@ -380,7 +380,7 @@ ID	LABEL
 {%- for mapping in project.sssom_mappingset_group.products %}
 ^^^ src/mappings/{{ mapping.id }}.sssom.tsv
 # curie_map:
-#   semapv: https://w3id.org/semapv/
+#   semapv: https://w3id.org/semapv/vocab/
 #   skos: http://www.w3.org/2004/02/skos/core#
 #   sssom: https://w3id.org/sssom/
 #   {{ project.id | upper }}: {{ project.uribase }}/{{ project.id | upper }}_

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1103,6 +1103,12 @@ $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:
 	wget "{{ mapping.mirror_from }}" -O $@
 endif
 
+{%       elif mapping.maintenance == "custom" -%}
+$(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:
+	@echo "ERROR: You have configured {{ mapping.id }} as a custom mapping set;"
+	@echo "       This rule needs to be overwritten in {{ project.id }}.Makefile!"
+	@false
+
 {%       endif -%}
 {%     endfor -%}
 {%   endif -%}

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -913,7 +913,7 @@ ifneq ($(SPARQL_EXPORTS_ARGS),)
 	$(ROBOT) query -f tsv --use-graphs true -i $< $(SPARQL_EXPORTS_ARGS)
 endif
 
-{%- if project.use_dosdps %}
+{% if project.use_dosdps -%}
 # ----------------------------------------
 # DOSDP Templates/Patterns
 # ----------------------------------------
@@ -1063,8 +1063,9 @@ else # PAT=false
 $(TMPDIR)/all_pattern_terms.txt: $(PATTERNDIR)/definitions.owl
 	$(ROBOT) query --use-graphs true -f csv -i $< --query $(SPARQLDIR)/terms.sparql $@
 endif
-{% endif %}
-{%- if project.use_mappings %}
+
+{% endif -%}
+{% if project.use_mappings -%}
 # ----------------------------------------
 # SSSOM Mapping Files
 # ----------------------------------------
@@ -1073,9 +1074,12 @@ validate-sssom-%:
 	tsvalid $(MAPPINGDIR)/$*.sssom.tsv --comment "#"
 	sssom validate $(MAPPINGDIR)/$*.sssom.tsv
 
-{%- if project.sssom_mappingset_group is not none %}
-{%- for mapping in project.sssom_mappingset_group.products %}
-{% if mapping.maintenance == "extract" %}
+validate_mappings:
+	$(MAKE_FAST) $(foreach n,$(MAPPINGS), validate-sssom-$(n))
+
+{%   if project.sssom_mappingset_group is not none -%}
+{%     for mapping in project.sssom_mappingset_group.products -%}
+{%       if mapping.maintenance == "extract" -%}
 $(TMPDIR)/{{ mapping.id }}.obographs.json: {% if mapping.source_file is not none %}{{ mapping.source_file }}{% else %}$(EDIT_PREPROCESSED){% endif %}
 	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert --check false -f json -o $@.tmp.json &&\
@@ -1083,25 +1087,25 @@ $(TMPDIR)/{{ mapping.id }}.obographs.json: {% if mapping.source_file is not none
 
 $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv: $(TMPDIR)/{{ mapping.id }}.obographs.json
 	sssom parse $< -I obographs-json {{ mapping.sssom_tool_options }} -o $@
-{%- elif mapping.maintenance == "manual" %}
+
+{%       elif mapping.maintenance == "manual" -%}
 # This mappingset is manually curated, so we only check that the file actually exists.
 $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:
 	test -f $@
-{%- elif mapping.maintenance == "mirror" %}
+
+{%       elif mapping.maintenance == "mirror" -%}
 ifeq ($(MIR),true)
 $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:
 	wget "{{ mapping.mirror_from }}" -O $@
 endif
-{%- endif %}
-{%- endfor %}
-{%- endif %}
 
-validate_mappings:
-	$(MAKE_FAST) $(foreach n,$(MAPPINGS), validate-sssom-$(n))
+{%       endif -%}
+{%     endfor -%}
+{%   endif -%}
 
-{% endif %}
+{% endif %}{# !project.use_mappings -#}
 
-{%- if project.use_translations %}
+{% if project.use_translations -%}
 # ----------------------------------------
 # Babelon Translation Files
 # ----------------------------------------
@@ -1177,8 +1181,8 @@ $(TRANSLATIONSDIR)/$(ONT)-all.babelon.tsv: $(TRANSLATIONS_TSV)
 
 $(TRANSLATIONSDIR)/%.babelon.json: $(TRANSLATIONSDIR)/%.babelon.tsv
 	$(BABELONPY) convert $< --output-format json -o $@
-{% endif %}
 
+{% endif -%}
 # ----------------------------------------
 # Release artefacts: export formats
 # ----------------------------------------

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1093,6 +1093,10 @@ $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv: $(TMPDIR)/{{ mapping.id }}.obographs.j
 $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:
 	test -f $@
 
+{%       elif mapping.maintenance == "merged" -%}
+$(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:{% for source in mapping.source_mappings %} $(MAPPINGDIR)/{{ source }}.sssom.tsv{% endfor %}
+	sssom-cli --output $@ $^
+
 {%       elif mapping.maintenance == "mirror" -%}
 ifeq ($(MIR),true)
 $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1080,14 +1080,23 @@ validate_mappings:
 {%   if project.sssom_mappingset_group is not none -%}
 {%     for mapping in project.sssom_mappingset_group.products -%}
 {%       if mapping.maintenance == "extract" -%}
+{%         if project.sssom_mappingset_group.mapping_extractor == "sssom-py" -%}
 $(TMPDIR)/{{ mapping.id }}.obographs.json: {{ mapping.source_file }}
-	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
-		convert --check false -f json -o $@.tmp.json &&\
-		mv $@.tmp.json $@
+	$(ROBOT) annotate --input $< \
+		          --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
+		 convert --check false --format json --output $@
 
 $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv: $(TMPDIR)/{{ mapping.id }}.obographs.json
 	sssom parse $< -I obographs-json {{ mapping.sssom_tool_options }} -o $@
 
+{%         elif project.sssom_mappingset_group.mapping_extractor == "robot" -%}
+$(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv: {{ mapping.source_file }} | all_robot_plugins
+	$(ROBOT) sssom:xref-extract --input $< \
+		                    --ignore-treat-xrefs \
+		                    --all-xrefs \
+		                    --mapping-file $@
+
+{%         endif -%}
 {%       elif mapping.maintenance == "manual" -%}
 # This mappingset is manually curated, so we only check that the file actually exists.
 $(MAPPINGDIR)/{{ mapping.id }}.sssom.tsv:

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1075,7 +1075,13 @@ validate-sssom-%:
 	sssom validate $(MAPPINGDIR)/$*.sssom.tsv
 
 validate_mappings:
-	$(MAKE_FAST) $(foreach n,$(MAPPINGS), validate-sssom-$(n))
+	$(MAKE_FAST) $(foreach n,$(MAPPINGS),validate-sssom-$(n))
+
+normalize-sssom-%:
+	sssom-cli --output $(MAPPINGDIR)/$*.sssom.tsv $(MAPPINGDIR)/$*.sssom.tsv
+
+normalize_mappings:
+	$(MAKE_FAST) $(foreach n,$(MAPPINGS),normalize-sssom-$(n))
 
 {%   if project.sssom_mappingset_group is not none -%}
 {%     for mapping in project.sssom_mappingset_group.products -%}

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1080,7 +1080,7 @@ validate_mappings:
 {%   if project.sssom_mappingset_group is not none -%}
 {%     for mapping in project.sssom_mappingset_group.products -%}
 {%       if mapping.maintenance == "extract" -%}
-$(TMPDIR)/{{ mapping.id }}.obographs.json: {% if mapping.source_file is not none %}{{ mapping.source_file }}{% else %}$(EDIT_PREPROCESSED){% endif %}
+$(TMPDIR)/{{ mapping.id }}.obographs.json: {{ mapping.source_file }}
 	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert --check false -f json -o $@.tmp.json &&\
 		mv $@.tmp.json $@

--- a/tests/test-sssom.yaml
+++ b/tests/test-sssom.yaml
@@ -19,6 +19,13 @@ sssom_mappingset_group:
       maintenance: extract
     - id: modmini-ontd
       maintenance: manual
+    - id: modmini-onte
+      maintenance: merged
+      source_mappings:
+        - modmini-onta
+        - modmini-ontb
+    - id: modmini-ontf
+      maintenance: merged
 components:
   products:
     - filename: test-with-sssom.owl


### PR DESCRIPTION
This PR primarily adds a new value for the `maintenance` field of SSSOM mapping sets declared in the `sssom_mappingset_group`: `merged`.

Given the following configuration:

```yaml
sssom_mappingset_group:
  products:
    - id: my-set-a
    - id: my-set-b
    - id: my-merged-set
      maintenance: merged
      source_mappings:
        - my-set-a
        - my-set-b
```

The `my-merged-set.sssom.tsv` set will be created by merging the `my-set-a.sssom.tsv` and `my-set-b.sssom.tsv` sets.

If `source_mappings` is not set for a `merged` set, the default behaviour is to use all the other sets as source, so the example above is actually equivalent to:

```yaml
sssom_mappingset_group:
  products:
    - id: my-set-a
    - id: my-set-b
    - id: my-merged-set
      maintenance: merged
```

(This is as discussed in #106.)

This PR also brings a few other changes to the SSSOM workflows:

A. Another `maintenance` value, `custom`, to explicitly declare that a set is to be built using a custom rule in the custom Makefile (similarly to the `module_type: custom` for import modules).

B. The possibility to use the `xref-extract` command of the SSSOM ROBOT plugin, rather than `sssom-py parse`, to extract mappings from an ontology. This is done with a new group-level option, `mapping_extractor`. The default value for that option is `sssom-py`, which preserves the existing behaviour of using `sssom-py parse`. If set to `robot`, mappings would be extracted using `robot sssom:xref-extract`.

C. New helper rules to force mapping sets to be re-serialized, similarly to the `normalize_src` rule (`normalize-sssom-X` to re-serialize mapping set _X_, `normalize_mappings` to re-serialize all sets).

closes #106