### PR TITLE
Always use context file if requested.

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -35,7 +35,10 @@ EDIT_FORMAT=                {{ project.edit_format|default('owl') }}
 SRC =                       $(ONT)-edit.$(EDIT_FORMAT)
 MAKE_FAST=                  $(MAKE) IMP=false PAT=false COMP=false MIR=false
 CATALOG=                    {{ project.catalog_file }}
-ROBOT=                      robot --catalog $(CATALOG)
+{% if project.use_context -%}
+CONTEXT_FILE =              config/context.json
+{% endif -%}
+ROBOT=                      robot --catalog $(CATALOG){% if project.use_context %} --add-prefixes $(CONTEXT_FILE){% endif %}
 REASONER=                   {{ project.reasoner }}
 RELEASEDIR=                 ../..
 DOCSDIR=                    ../../docs
@@ -69,12 +72,9 @@ ANNOTATE_CONVERT_FILE =     annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONT
 OTHER_SRC =                 {% if project.use_dosdps -%}$(PATTERNDIR)/definitions.owl {% endif -%}{% if project.components is defined -%}{% for component in project.components.products -%}$(COMPONENTSDIR)/{{ component.filename }} {% endfor -%}{% endif %}
 ONTOLOGYTERMS =             $(TMPDIR)/ontologyterms.txt
 EDIT_PREPROCESSED =         $(TMPDIR)/$(ONT)-preprocess.owl
-{%- if project.use_context %}
-CONTEXT_FILE =              config/context.json
-{%- if 'db' in project.export_formats %}
+{% if project.use_context and 'db' in project.export_formats -%}
 CONTEXT_FILE_CSV =          $(TMPDIR)/context.csv
-{%- endif %}
-{%- endif %}
+{%- endif -%}
 
 {%- if project.use_dosdps %}
 PATTERNDIR=                 ../patterns


### PR DESCRIPTION
If the user requested the generation and use of a “context file”, then we ensure that said context file is systematically used in all calls to ROBOT.

closes #816