### PR TITLE
Misc fixes

### DIFF
--- a/scripts/odk-info.sh
+++ b/scripts/odk-info.sh
@@ -51,9 +51,6 @@ if [ $show_tools_version -eq 1 ]; then
     if type -p amm > /dev/null ; then
         amm --version
     fi
-    if type -p scala-cli > /dev/null ; then
-        scala-cli --version 2>/dev/null | head -n 1 | tr -d :
-    fi
     if type -p sssom-cli > /dev/null ; then
         sssom-cli --version | sed -ne 's/^sssom-cli (SSSOM-Java \(.*\))/SSSOM-CLI version \1/p'
     fi

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1067,6 +1067,8 @@ else # PAT=false
 # Even if pattern generation is disabled, we still extract a seed from definitions.owl
 $(TMPDIR)/all_pattern_terms.txt: $(PATTERNDIR)/definitions.owl
 	$(ROBOT) query --use-graphs true -f csv -i $< --query $(SPARQLDIR)/terms.sparql $@
+
+dosdp_validation:
 endif
 
 {% endif -%}

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -40,6 +40,11 @@ CONTEXT_FILE =              config/context.json
 {% endif -%}
 ROBOT=                      robot --catalog $(CATALOG){% if project.use_context %} --add-prefixes $(CONTEXT_FILE){% endif %}
 REASONER=                   {{ project.reasoner }}
+{# Kept for backwards compatibility with existing custom Makefiles -#}
+{% if project.owltools_memory|length -%}
+OWLTOOLS_MEMORY =           {{ project.owltools_memory }}
+{% endif -%}
+OWLTOOLS =                  {% if project.owltools_memory|length %}OWLTOOLS_MEMORY=$(OWLTOOLS_MEMORY) {% endif %}owltools --use-catalog
 RELEASEDIR=                 ../..
 DOCSDIR=                    ../../docs
 REPORTDIR=                  reports


### PR DESCRIPTION
This PR fixes a handful of issues with the current pipelines:

* It disables the systematic printing of Scala-CLI’s version number, which takes **several seconds** every time.
* It restores the `OWLTOOLS` variable in the standard Makefile; though it is no longer used there, custom Makefiles might still be dependent on it (e.g. Uberon).
* It allows running the test suite (or any other pipeline dependent on the `test` target) with the pattern pipeline disabled (PAT=false).