### PR TITLE
Test ROBOT 1.10.0 release candidate

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -42,9 +42,15 @@ RUN apt-get update && \
 COPY --from=obolibrary/odkbuild:latest /staging/lite /
 
 # Install ROBOT.
-RUN wget -nv $ROBOT_JAR \
-        -O /tools/robot.jar && \
-    wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/bin/robot \
+# ROBOT 1.10.0 release candidate is available from here:
+# https://github.com/ontodev/robot/actions/runs/14932625035/artifacts/3095150701
+# but that link only works in an authenticated GitHub session (e.g. from
+# a web browser while connected to a GitHub account), *not* from an
+# unauthenticated command line client like wget. Manually download the
+# robot.jar archive using that link and put it in the top-level
+# directory.
+COPY robot.jar /tools/robot.jar
+RUN wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/bin/robot \
         -O /tools/robot && \
     chmod 755 /tools/robot &&\
     mkdir -p /tools/templates/src/ontology &&\

--- a/odk/odk.py
+++ b/odk/odk.py
@@ -791,7 +791,7 @@ class OntologyProject(JsonSchemaMixin):
     """Emails to use in travis configurations. """
     
     obo_format_options : str = ""
-    """Additional args to pass to robot when saving to obo. TODO consider changing to a boolean for checks"""
+    """Additional args to pass to robot when saving to obo. The default is '--clean-obo "strict drop-untranslatable-axioms"'."""
 
     catalog_file : str = "catalog-v001.xml"
     """Name of the catalog file to be used by the build."""
@@ -854,7 +854,8 @@ class OntologyProject(JsonSchemaMixin):
         The config can be lazy and just specify an id list.
         These are used to create stub product objects.
 
-        (this adds complexity and may be removed)
+        This method is also intended to perform any checks
+        and initialisations on the entire configuration tree.
         """
         if self.import_group is not None:
             self.import_group.fill_missing(self)
@@ -866,6 +867,11 @@ class OntologyProject(JsonSchemaMixin):
             self.sssom_mappingset_group.fill_missing(self)
         if self.components is not None:
             self.components.fill_missing(self)
+
+        if not '--clean-obo' in self.obo_format_options:
+            if len(self.obo_format_options) > 0:
+                self.obo_format_options += ' '
+            self.obo_format_options += '--clean-obo "strict drop-untranslatable-axioms"'
 
 @dataclass
 class ExecutionContext(JsonSchemaMixin):

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -916,7 +916,7 @@ $(SUBSETDIR)/%.owl: $(ONT).owl | $(SUBSETDIR) all_robot_plugins
 
 {% if 'obo' in project.export_formats %}
 $(SUBSETDIR)/%.obo: $(SUBSETDIR)/%.owl
-	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
+	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@
 {% endif -%}
 {% if 'ttl' in project.export_formats %}
 $(SUBSETDIR)/%.ttl: $(SUBSETDIR)/%.owl
@@ -1248,7 +1248,7 @@ $(TRANSLATIONSDIR)/%.babelon.json: $(TRANSLATIONSDIR)/%.babelon.tsv
 {% if r.startswith('custom-') %}{% set release = r | replace("custom-","") %}{% else %}{% set release = "$(ONT)-" ~ r %}{% endif -%}
 {% if 'obo' in project.export_formats -%}
 {{ release }}.obo: {{ release }}.owl
-	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
+	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@
 {% endif -%}
 {% if 'ttl' in project.export_formats -%}
 {{ release }}.ttl: {{ release }}.owl
@@ -1286,7 +1286,7 @@ $(ONT).owl: $(ONT)-{{ project.primary_release }}.owl
 
 {% if 'obo' in project.export_formats -%}
 $(ONT).obo: $(ONT).owl
-	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@.tmp.obo && grep -v ^owl-axioms $@.tmp.obo > $@ && rm $@.tmp.obo
+	$(ROBOT) convert --input $< --check false -f obo $(OBO_FORMAT_OPTIONS) -o $@
 {% endif -%}
 {% if 'ttl' in project.export_formats -%}
 $(ONT).ttl: $(ONT).owl

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -68,6 +68,7 @@ SPARQL_VALIDATION_CHECKS =  {% for x in project.robot_report.custom_sparql_check
 SPARQL_EXPORTS =            {% for x in project.robot_report.custom_sparql_exports|default(['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms']) %}{{ x }} {% endfor %}
 ODK_VERSION_MAKEFILE =      {% if env is defined %}{{env['ODK_VERSION'] or "Unknown" }}{% else %}"Unknown"{% endif %}
 RELAX_OPTIONS =             --include-subclass-of true
+REDUCE_OPTIONS =            --include-subproperties true
 
 TODAY ?=                    $(shell date +%Y-%m-%d)
 OBODATE ?=                  $(shell date +'%d:%m:%Y %H:%M')
@@ -1339,7 +1340,7 @@ $(ONT)-base.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(IMPORT_FILES)
 	reason --reasoner $(REASONER) --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} --annotate-inferred-axioms {{ project.release_annotate_inferred_axioms|default('false')|lower }} \{% if project.release_materialize_object_properties is defined and project.release_materialize_object_properties %}
 	materialize {% for iri in project.release_materialize_object_properties %}--term {{iri}} {% endfor %} \{% endif %}{% endif %}
 	relax $(RELAX_OPTIONS) \{% if project.release_use_reasoner %}
-	reduce -r $(REASONER) \{% endif %}
+	reduce -r $(REASONER) $(REDUCE_OPTIONS) \{% endif %}
 	remove {% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{iri}} {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }} {% endif %}--axioms external --preserve-structure false --trim false \
 	$(SHARED_ROBOT_COMMANDS) \
 	annotate --link-annotation http://purl.org/dc/elements/1.1/type http://purl.obolibrary.org/obo/IAO_8000001 \
@@ -1362,7 +1363,7 @@ $(ONT)-full.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(IMPORT_FILES)
 		reason --reasoner $(REASONER) --equivalent-classes-allowed {{ project.allow_equivalents }} --exclude-tautologies {{ project.exclude_tautologies }} \{% if project.release_materialize_object_properties is defined and project.release_materialize_object_properties %}
 		materialize {% for iri in project.release_materialize_object_properties %}--term {{iri}} {% endfor %} \{% endif %}
 		relax $(RELAX_OPTIONS) \
-		reduce -r $(REASONER) \
+		reduce -r $(REASONER) $(REDUCE_OPTIONS) \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) {% if project.release_date -%}--annotation oboInOwl:date "$(OBODATE)" {% endif -%}--output $@.tmp.owl && mv $@.tmp.owl $@
 {% endif -%}
 
@@ -1383,7 +1384,7 @@ $(ONT)-simple.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(IMPORT_FILE
 		relax $(RELAX_OPTIONS) \
 		remove --axioms equivalent \
 		filter --term-file $(SIMPLESEED) --select "annotations ontology anonymous self" --trim true --signature true \{% if project.release_use_reasoner %}
-		reduce -r $(REASONER) \{% endif %}
+		reduce -r $(REASONER) $(REDUCE_OPTIONS) \{% endif %}
 		odk:normalize --base-iri {{ project.uribase }} --subset-decls true --synonym-decls true \
 		repair --merge-axiom-annotations true \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) {% if project.release_date -%}--annotation oboInOwl:date "$(OBODATE)" {% endif -%}--output $@.tmp.owl && mv $@.tmp.owl $@
@@ -1396,7 +1397,7 @@ $(ONT)-simple.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(IMPORT_FILE
 $(ONT)-simple-non-classified.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(IMPORT_FILES)
 	$(ROBOT_RELEASE_IMPORT_MODE_BASE) \
 		remove --axioms equivalent \{% if project.release_use_reasoner %}
-		reduce -r $(REASONER) \{% endif %}
+		reduce -r $(REASONER) $(REDUCE_OPTIONS) \{% endif %}
 		filter --select ontology --term-file $(SIMPLESEED) --trim false \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) {% if project.release_date -%}--annotation oboInOwl:date "$(OBODATE)" {% endif -%}--output $@.tmp.owl && mv $@.tmp.owl $@
 {% endif -%}
@@ -1421,7 +1422,7 @@ $(ONT)-basic.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(KEEPRELATION
 		remove --axioms disjoint \
 		remove --term-file $(KEEPRELATIONS) --select complement --select object-properties --trim true \
 		filter --term-file $(SIMPLESEED) --select "annotations ontology anonymous self" --trim true --signature true \
-		reduce -r $(REASONER) \
+		reduce -r $(REASONER) $(REDUCE_OPTIONS) \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) {% if project.release_date -%}--annotation oboInOwl:date "$(OBODATE)" {% endif -%}--output $@.tmp.owl && mv $@.tmp.owl $@
 {% endif -%}
 {% for r in project.release_artefacts %}

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -542,7 +542,7 @@ $(IMPORTDIR)/merged_import.owl: $(MIRRORDIR)/merged.owl $(ALL_TERMS) \
 		        --select complement --select annotation-properties \{% endif %}
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true \
+		 repair --merge-axiom-annotations true \
 		 $(ANNOTATE_CONVERT_FILE)
 
 {%     else -%}
@@ -559,8 +559,8 @@ $(IMPORTDIR)/merged_import.owl: $(MIRRORDIR)/merged.owl $(ALL_TERMS) \
 {%     if 'slme' == project.import_group.module_type -%}
 $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 			   $(IMPORTSEED) | all_robot_plugins
-	$(ROBOT) annotate --input $< --remove-annotations \
-		 odk:normalize --add-source true \
+	$(ROBOT) annotate --input $< --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 extract --term-file $(IMPORTDIR)/$*_terms.txt $(T_IMPORTSEED) \
 		         --force true --copy-ontology-annotations true \
 		         --individuals {{ project.import_group.slme_individuals }} \
@@ -570,14 +570,14 @@ $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 		        --select complement --select annotation-properties \{% endif %}
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true \
+		 repair --merge-axiom-annotations true \
 		 $(ANNOTATE_CONVERT_FILE)
 
 {%     elif 'minimal' == project.import_group.module_type -%}
 $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 			   $(IMPORTSEED) | all_robot_plugins
-	$(ROBOT) annotate --input $< --remove-annotations \
-		 odk:normalize --add-source true \
+	$(ROBOT) annotate --input $< --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 extract --term-file $(IMPORTDIR)/$*_terms.txt $(T_IMPORTSEED) \
 		         --force true --copy-ontology-annotations true \
 		         --method BOT \
@@ -586,7 +586,7 @@ $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 		        --preserve-structure false --trim false \
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true \
+		 repair --merge-axiom-annotations true \
 		 remove $(foreach p, $(ANNOTATION_PROPERTIES), --term $(p)) \
 		        --term-file $(IMPORTDIR)/$*_terms.txt $(T_IMPORTSEED) \
 		        --select complement \
@@ -595,18 +595,19 @@ $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 
 {%     elif 'mirror' == project.import_group.module_type -%}
 $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl | all_robot_plugins
-	$(ROBOT) annotate --input $< --remove-annotations \
+	$(ROBOT) annotate --input $< --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true --add-source true \
+		 repair --merge-axiom-annotations true \
 		 $(ANNOTATE_CONVERT_FILE)
 
 {%     elif 'filter' == project.import_group.module_type -%}
 $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 			   $(IMPORTSEED) | all_robot_plugins
 	$(ROBOT) merge --input $< \
-		 annotate --remove-annotations \
-		 odk:normalize --add-source true \
+		 annotate --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 remove --base-iri $(OBOBASE)"/$(shell echo $* | tr a-z A-Z)_" \
 		        --axioms external \
 		        --preserve-structure false --trim false \
@@ -615,7 +616,7 @@ $(IMPORTDIR)/%_import.owl: $(MIRRORDIR)/%.owl $(IMPORTDIR)/%_terms.txt \
 		        --select complement \
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true \
+		 repair --merge-axiom-annotations true \
 		 $(ANNOTATE_CONVERT_FILE)
 
 {%     elif 'custom' == project.import_group.module_type -%}
@@ -642,8 +643,8 @@ ifeq ($(IMP_LARGE),true)
 {%       endif -%}
 {%       if 'slme' == ont.module_type -%}
 $(IMPORTDIR)/{{ ont.id }}_import.owl: $(MIRRORDIR)/{{ ont.id }}.owl $(IMPORTDIR)/{{ ont.id }}_terms.txt $(IMPORTSEED) | all_robot_plugins
-	$(ROBOT) annotate --input $< --remove-annotations \
-		 odk:normalize --add-source true \
+	$(ROBOT) annotate --input $< --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 extract --term-file $(IMPORTDIR)/{{ ont.id }}_terms.txt $(T_IMPORTSEED) \
 		         --copy-ontology-annotations true --force true \
 		         --individuals {{ ont.slme_individuals }} \
@@ -654,12 +655,12 @@ $(IMPORTDIR)/{{ ont.id }}_import.owl: $(MIRRORDIR)/{{ ont.id }}.owl $(IMPORTDIR)
 		        --select complement --select annotation-properties \{% endif %}
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true \
+		 repair --merge-axiom-annotations true \
 		 $(ANNOTATE_CONVERT_FILE)
 {%       elif 'filter' == ont.module_type -%}
 $(IMPORTDIR)/{{ ont.id }}_import.owl: $(MIRRORDIR)/{{ ont.id }}.owl $(IMPORTDIR)/{{ ont.id }}_terms.txt $(IMPORTSEED) | all_robot_plugins
-	$(ROBOT) annotate --input $< --remove-annotations \
-		 odk:normalize --add-source true \
+	$(ROBOT) annotate --input $< --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 extract --term-file $(IMPORTDIR)/{{ ont.id }}_terms.txt $(T_IMPORTSEED) \
 		         --copy-ontology-annotations true --force true --method BOT \
 		 remove --axioms external --preserve-structure false --trim false \{% for iri in ont.base_iris %}
@@ -670,25 +671,27 @@ $(IMPORTDIR)/{{ ont.id }}_import.owl: $(MIRRORDIR)/{{ ont.id }}.owl $(IMPORTDIR)
 		        --select complement \
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true \
+		 repair --merge-axiom-annotations true \
 		 $(ANNOTATE_CONVERT_FILE)
 {%       elif 'mirror' == ont.module_type -%}
 $(IMPORTDIR)/{{ ont.id }}_import.owl: $(MIRRORDIR)/{{ ont.id }}.owl | all_robot_plugins
-	$(ROBOT) annotate --input $< --remove-annotations \
+	$(ROBOT) annotate --input $< --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 odk:normalize --base-iri {{ project.uribase }} \
 		               --subset-decls true --synonym-decls true \
-		               --merge-axioms true --add-source true \
+		 repair --merge-axiom-annotations true \
 		 $(ANNOTATE_CONVERT_FILE)
 {%       elif 'minimal' == ont.module_type -%}
 $(IMPORTDIR)/{{ ont.id }}_import.owl: $(MIRRORDIR)/{{ ont.id }}.owl $(IMPORTDIR)/{{ ont.id }}_terms.txt $(IMPORTSEED) | all_robot_plugins
-	$(ROBOT) annotate --input $< --remove-annotations \
-		 odk:normalize --add-source true \
+	$(ROBOT) annotate --input $< --remove-annotations --interpolate true \
+		          --link-annotation dc:source "%{version_iri}" \
 		 extract --term-file $(IMPORTDIR)/{{ ont.id }}_terms.txt $(T_IMPORTSEED) \
 		         --copy-ontology-annotations true --force true --method BOT \
 		 remove --axioms external --preserve-structure false --trim false \{% for iri in ont.base_iris %}
 		        --base-iri {{ iri }} \{% endfor %}
 		 odk:normalize --base-iri {{ project.uribase }} --subset-decls true \
-		               --synonym-decls true --merge-axioms true \
+		               --synonym-decls true \
+		 repair --merge-axiom-annotations true \
 		 remove $(foreach p, $(ANNOTATION_PROPERTIES), --term $(p)) \{% for p in ont.annotation_properties %}
 		        --term {{ p }} \{% endfor %}
 		        --term-file $(IMPORTDIR)/{{ ont.id }}_terms.txt $(T_IMPORTSEED) \
@@ -1381,7 +1384,8 @@ $(ONT)-simple.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(SIMPLESEED) $(IMPORT_FILE
 		remove --axioms equivalent \
 		filter --term-file $(SIMPLESEED) --select "annotations ontology anonymous self" --trim true --signature true \{% if project.release_use_reasoner %}
 		reduce -r $(REASONER) \{% endif %}
-		odk:normalize --base-iri {{ project.uribase }} --subset-decls true --synonym-decls true --merge-axioms true \
+		odk:normalize --base-iri {{ project.uribase }} --subset-decls true --synonym-decls true \
+		repair --merge-axiom-annotations true \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) {% if project.release_date -%}--annotation oboInOwl:date "$(OBODATE)" {% endif -%}--output $@.tmp.owl && mv $@.tmp.owl $@
 {% endif -%}
 
@@ -1521,7 +1525,7 @@ validate-all-tsv: $(ALL_TSV_FILES)
 {% if 'obo' in project.edit_format -%}
 .PHONY: normalize_obo_src
 normalize_obo_src: $(SRC) | all_robot_plugins
-	$(ROBOT) odk:normalize -i $< --merge-axioms true \
+	$(ROBOT) repair -i $< --merge-axiom-annotations true \
 		 convert -o $(TMPDIR)/NORM.tmp.obo && \
 	mv $(TMPDIR)/NORM.tmp.obo $(SRC)
 {%- endif %}


### PR DESCRIPTION
/!\ Not for merging /!\

This is a draft PR only, intended to allow building a development snapshot of the ODK to test the release candidate of ROBOT 1.10.0.

The archive of that release candidate is not *publicly* available (a GitHub account is required to follow the link to the archive), so for the purpose of that test we assume that the robot.jar file has been manually downloaded and is available in the top-level directory.