### PR TITLE
Fix update_repo when there are no components.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -1190,8 +1190,9 @@ def update_import_declarations(project, pluginsdir='/tools/robot-plugins'):
     else:
         for product in project.import_group.products:
             cmd += f' --add {base}/imports/{product.id}_import.owl'
-    for component in project.components.products:
-        cmd += f' --add {base}/components/{component.filename}'
+    if project.components is not None:
+        for component in project.components.products:
+            cmd += f' --add {base}/components/{component.filename}'
     if project.use_dosdps:
         cmd += f' --add {base}/patterns/definitions.owl'
         if project.import_pattern_ontology:


### PR DESCRIPTION
Updating a repo that does not declare any component fails because the code that updates the import declarations assumes that the project.components group always exist, which is of course not the case when there are no components.