### PR TITLE
Update the 'build-multiarch' workflow.

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -2,6 +2,15 @@ name: Build and publish the multi-arch ODK images
 
 on:
   workflow_dispatch:
+    inputs:
+      buildType:
+        description: 'Type of image to build'
+        required: true
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - snapshot
 
 jobs:
   build:
@@ -10,15 +19,17 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v4
       - name: Set up the QEMU static binaries
-        uses: docker/setup-qemu-action@v1
-        with:
-          platforms: all
-      - name: Create a builder instance
-        run: docker buildx create --use
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push the images
+      - name: Build and push the release images
+        if: ${{ inputs.buildType == 'release' }}
         run: make publish-multiarch
+      - name: Build and push the snapshot images
+        if: ${{ inputs.buildType == 'snapshot' }}
+        run: make publish-multiarch-dev


### PR DESCRIPTION
The `build-multiarch` workflow had been used for a brief time in 2021 to automatically build and publish the Docker images to the Docker Hub directly from GitHub.

We stopped using it after PR #475, because by then building the multiarch images took too long (more than 6 hours) and the process always ended up being killed by GitHub.

However, (1) this was nearly 4 years ago, so maybe the runners are now faster, and (2) more importantly, 4 years ago we were building Konclude on arm64 from source, which was the most time-consuming part of the build. We are no longer doing that, instead we use a pre-built version of Konclude for arm64.

So it is worth trying to reactivate that workflow, which is what this PR is about. Here, we update the Docker-provided actions used by the workflow, and add a parameter to allow choosing between building the "release" images (as the original workflow) or building a development snapshot.