### PR TITLE
Ignore properties file from OBDA Protégé plugin.

### DIFF
--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -45,6 +45,7 @@ src/ontology/ontologyterms.txt
 src/ontology/simple_seed.txt
 src/ontology/patterns
 src/ontology/merged-{{ project.id }}-edit.owl
+src/ontology/{{ project.id }}-edit.properties
 
 src/ontology/target/
 src/ontology/tmp/*


### PR DESCRIPTION
The "OntopOBDA" plugin for Protégé automatically creates a MYONT.properties file when Protégé is editing a MYONT.owl file. In many cases that file is not wanted, so by default it should not be committed.

If users do want to commit that file (maybe because they changed the configuration of the plugin, and want their settings saved), all they have to do is to force Git to commit (`git add -f ...`).

closes #1220