### PR TITLE
Add merge_template workflow to Makefile

### DIFF
--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1532,7 +1532,12 @@ TEMPLATE_URL=
 # The tmp/merge_template.tsv is hardcoded as placeholder for downloading template files
 # from a remote location
 tmp/merge_template.tsv:
-	wget "$(TEMPLATE_URL)" -O $@
+	@if [ -z "$(TEMPLATE_URL)" ]; then \
+		echo "ERROR: No TEMPLATE_URL defined. Please set TEMPLATE_URL to download the merge template."; \
+		exit 1; \
+	else \
+		wget "$(TEMPLATE_URL)" -O $@; \
+	fi
 
 merge_template: $(MERGE_TEMPLATE)
 	$(ROBOT) template $(MERGE_TEMPLATE_OPTIONS) --input $(SRC) \

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1522,10 +1522,17 @@ validate-all-tsv: $(ALL_TSV_FILES)
 # The merge template workflow is commonly used when ontology content is curated in a ROBOT template
 # with the intention to merge it directly into the editors file. The idea is to either create a template
 # manually or create a rule in {{ project.id }}.Makefile to download a template from, e.g., a Google Sheet, and then run
-# `./run.sh MERGE_TEMPLATE=tmp/merge_my_template.tsv merge_template` to merge the template into the editors file.
+# `sh run.sh make MERGE_TEMPLATE=tmp/merge_my_template.tsv merge_template` to merge the template into the editors file or
+# `sh run.sh make TEMPLATE_URL=http://example.org/merge_my_template.tsv merge_template` to download and then merge the template
 
 MERGE_TEMPLATE=tmp/merge_template.tsv
 MERGE_TEMPLATE_OPTIONS= --merge-before
+TEMPLATE_URL=
+
+# The tmp/merge_template.tsv is hardcoded as placeholder for downloading template files
+# from a remote location
+tmp/merge_template.tsv:
+	wget "$(TEMPLATE_URL)" -O $@
 
 merge_template: $(MERGE_TEMPLATE)
 	$(ROBOT) template $(MERGE_TEMPLATE_OPTIONS) --input $(SRC) \

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -1519,6 +1519,18 @@ validate-all-tsv: $(ALL_TSV_FILES)
 # Editors Utilities
 # ----------------------------------------
 
+# The merge template workflow is commonly used when ontology content is curated in a ROBOT template
+# with the intention to merge it directly into the editors file. The idea is to either create a template
+# manually or create a rule in {{ project.id }}.Makefile to download a template from, e.g., a Google Sheet, and then run
+# `./run.sh MERGE_TEMPLATE=tmp/merge_my_template.tsv merge_template` to merge the template into the editors file.
+
+MERGE_TEMPLATE=tmp/merge_template.tsv
+MERGE_TEMPLATE_OPTIONS= --merge-before
+
+merge_template: $(MERGE_TEMPLATE)
+	$(ROBOT) template $(MERGE_TEMPLATE_OPTIONS) --input $(SRC) \
+			--template $(MERGE_TEMPLATE) convert -f $(EDIT_FORMAT) -o $(SRC)
+
 # This is an experimental target people that want to use ODK Extended Prefix Map (EPM)
 # can use to pull the (currently inofficial) OBO EPM into the workspace.
 # Users are instructed to refer to the EPM only through the variable $(EXTENDED_PREFIX_MAP) as 


### PR DESCRIPTION
fixes #579 

The `merge_template` workflow is in no way dependent on any other rule - isolated from the rest of the Makefile - so this addition is low risk.

But I am not 1000% set on this PR. I know in Mondo we use this workflow a lot; I have used it sometimes in HPO, MAXO and OMO.

Let me know your thoughts @gouttegd!