### PR TITLE
[PoC] Allow changing the configuration schema transparently for users

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -932,6 +932,7 @@ class Generator(object):
                 config_hash = h.hexdigest()
                 stream.seek(0)
                 obj = yaml.load(stream, Loader=yaml.FullLoader)
+            preprocess_config_dict(obj)
             project = from_dict(data_class=OntologyProject, data=obj)
         if config_hash:
             project.config_hash = config_hash
@@ -947,6 +948,79 @@ class Generator(object):
             project.import_group.ids = imports
         project.fill_missing()
         self.context = ExecutionContext(project=project)
+
+
+def preprocess_config_dict(obj):
+    """
+    Updates a config dictionary to replace keys that have been renamed
+    or moved.
+    """
+    changes = [
+            # old key path               new key path
+            ('example.old.key',         'example.new.key')
+            ]
+    for old, new in changes:
+        v = pop_key(obj, old)
+        if v is not None:
+            if new is not None:
+                logging.warning(f"Option {old} is deprecated, use {new} instead")
+                put_key(obj, new, v)
+            else:
+                logging.warning(f"Option {old} is deprecated")
+
+def pop_key(obj, path):
+    """
+    Gets the value of the key at the specified path, exploring
+    subdictionaries recursively as needed. The terminal key, if found,
+    is removed from the dictionary.
+
+    For example,
+
+      pop_key(my_dict, 'path.to.key')
+
+    is equivalent to
+
+      my_dict.get('path', {}).get('to', {}).pop('key', None)
+
+    Returns None if any of the keys does not exist, or if one of the
+    parent keys exists but is not a dictionary.
+    """
+    components = path.split('.')
+    n = len(components)
+    for i, component in enumerate(components):
+        if i < n - 1:
+            obj = obj.get(component)
+            if not isinstance(obj, dict):
+                return None
+        else:
+            return obj.pop(component, None)
+
+def put_key(obj, path, value):
+    """
+    Puts a value in a dictionary at the specified path, going through
+    subdictionaries recursively as needed.
+
+    For example,
+
+      put_key(my_dict, 'path.to.key', value)
+
+    is almost equivalent to
+
+      my_dict['path']['to']['key'] = value
+
+    except that intermediate dictionaries are automatically created if
+    they do not already exist.
+    """
+    components = path.split('.')
+    n = len(components)
+    for i, component in enumerate(components):
+        if i < n - 1:
+            if not component in obj:
+                obj[component] = {}
+            obj = obj[component]
+        else:
+            obj[component] = value
+
 
 def save_project_yaml(project : OntologyProject, path : str):
     """
@@ -1296,7 +1370,20 @@ def export_project(config, output):
         raise click.ClickException(format_yaml_error(config, exc))
     project = mg.context.project
     save_project_yaml(project, output)
-    
+
+@cli.command()
+@click.option('-C', '--config', type=click.Path(exists=True))
+@click.option('-o', '--output', required=True)
+def update_config(config, output):
+    """
+    Updates a configuration file to account for renamed or moved options.
+    """
+    with open(config, 'r') as f:
+        cfg = yaml.load(f, Loader=yaml.FullLoader)
+    preprocess_config_dict(cfg)
+    with open(output, 'w') as f:
+        f.write(yaml.dump(cfg, default_flow_style=False))
+
 @cli.command()
 @click.option('-c', '--class_name', type=str, default="OntologyProject")
 def dump_schema(class_name):

--- a/template/_dynamic_documentation.jinja2
+++ b/template/_dynamic_documentation.jinja2
@@ -791,19 +791,20 @@ We can define custom checks using [SPARQL](https://www.w3.org/TR/rdf-sparql-quer
 
 1. Add the SPARQL query in `src/sparql`. The name of the file should end with `-violation.sparql`. Please give a name that helps to understand which violation the query wants to check.
 2. Add the name of the new file to odk configuration file `src/ontology/uberon-odk.yaml`:
-    1. Include the name of the file (without the `-violation.sparql` part) to the list inside the key `custom_sparql_checks` that is inside `robot_report` key.
-    1. If the `robot_report` or `custom_sparql_checks` keys are not available, please add this code block to the end of the file.
+    1. Include the name of the file (without the `-violation.sparql` part) to the list inside the key `custom_sparql_checks` that is inside `robot.report` key.
+    1. If the `robot.report` or `custom_sparql_checks` keys are not available, please add this code block to the end of the file.
 
         ``` yaml
-          robot_report:
-            release_reports: False
-            fail_on: ERROR
-            use_labels: False
-            custom_profile: True
-            report_on:
-              - edit
-            custom_sparql_checks:
-              - name-of-the-file-check
+          robot:
+            report:
+              release_reports: False
+              fail_on: ERROR
+              use_labels: False
+              custom_profile: True
+              report_on:
+                - edit
+              custom_sparql_checks:
+                - name-of-the-file-check
         ```
 3. Update the repository so your new SPARQL check will be included in the QC.
 

--- a/template/_dynamic_sparql.jinja2
+++ b/template/_dynamic_sparql.jinja2
@@ -17,7 +17,7 @@ WHERE {
 {#
     SPARQL QUERY QC checks
 -#}
-{% if project.robot_report.custom_sparql_checks is not defined or 'owldef-self-reference' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'owldef-self-reference' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/owldef-self-reference-violation.sparql
 PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
@@ -31,7 +31,7 @@ SELECT ?term WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'redundant-subClassOf' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'redundant-subClassOf' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/redundant-subClassOf-violation.sparql
 PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -48,7 +48,7 @@ SELECT ?term ?xl ?y ?yl ?z ?zl WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'taxon-range' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'taxon-range' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/taxon-range-violation.sparql
 PREFIX never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
 PREFIX present_in_taxon: <http://purl.obolibrary.org/obo/RO_0002175>
@@ -61,7 +61,7 @@ WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'iri-range' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'iri-range' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/iri-range-violation.sparql
 PREFIX never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
 PREFIX present_in_taxon: <http://purl.obolibrary.org/obo/RO_0002175>
@@ -82,7 +82,7 @@ WHERE {
   FILTER (!isIRI(?value))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'iri-range-advanced' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'iri-range-advanced' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/iri-range-advanced-violation.sparql
 PREFIX never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
 PREFIX present_in_taxon: <http://purl.obolibrary.org/obo/RO_0002175>
@@ -105,7 +105,7 @@ WHERE {
   FILTER (!isIRI(?value))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'label-with-iri' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'label-with-iri' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/label-with-iri-violation.sparql
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
@@ -116,7 +116,7 @@ WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'multiple-replaced_by' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'multiple-replaced_by' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/multiple-replaced_by-violation.sparql
 PREFIX replaced_by: <http://purl.obolibrary.org/obo/IAO_0100001>
 
@@ -130,7 +130,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   BIND(CONCAT(str(?value1), CONCAT("|", str(?value2))) as ?value)
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'term-tracker-uri' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'term-tracker-uri' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/term-tracker-uri-violation.sparql
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX term_tracker_item: <http://purl.obolibrary.org/obo/IAO_0000233>
@@ -141,7 +141,7 @@ SELECT ?term ?term_tracker ?term_tracker_type WHERE {
   BIND(DATATYPE(?term_tracker) as ?term_tracker_type) 
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'illegal-date' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'illegal-date' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/illegal-date-violation.sparql
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -155,7 +155,7 @@ SELECT DISTINCT ?term ?property ?value WHERE
   FILTER (datatype(?value) != xsd:dateTime || !regex(str(?value), '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z'))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'dc-properties' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'dc-properties' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/dc-properties-violation.sparql
 # The purpose of this violation is to make sure people update
 # from using the deprecated DC Elements 1.1 namespace (http://purl.org/dc/elements/1.1/)

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -39,7 +39,7 @@ CATALOG=                    {{ project.catalog_file }}
 CONTEXT_FILE =              config/context.json
 {% endif -%}
 ROBOT=                      robot --catalog $(CATALOG){% if project.use_context %} --add-prefixes $(CONTEXT_FILE){% endif %}
-REASONER=                   {{ project.reasoner }}
+REASONER=                   {{ project.robot.reasoner }}
 {# Kept for backwards compatibility with existing custom Makefiles -#}
 {% if project.owltools_memory|length -%}
 OWLTOOLS_MEMORY =           {{ project.owltools_memory }}
@@ -57,18 +57,18 @@ SCRIPTSDIR=                 ../scripts
 UPDATEREPODIR=              target
 SPARQLDIR =                 ../sparql
 COMPONENTSDIR =             {{ project.components.directory|default('components') }}
-{%- if project.robot_report.custom_profile %}
+{%- if project.robot.report.custom_profile %}
 ROBOT_PROFILE =             profile.txt
 {%- endif %}
-REPORT_FAIL_ON =            {{ project.robot_report.fail_on|default('None') }}
-REPORT_LABEL =              {% if project.robot_report.use_labels|default(true) %}-l true{% endif %}
-REPORT_PROFILE_OPTS =       {% if project.robot_report.custom_profile %}--profile $(ROBOT_PROFILE){% endif %}
-OBO_FORMAT_OPTIONS =        {{ project.obo_format_options }}
-SPARQL_VALIDATION_CHECKS =  {% for x in project.robot_report.custom_sparql_checks|default(['owldef-self-reference', 'iri-range', 'label-with-iri', 'multiple-replaced_by']) %}{{ x }} {% endfor %}
-SPARQL_EXPORTS =            {% for x in project.robot_report.custom_sparql_exports|default(['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms']) %}{{ x }} {% endfor %}
+REPORT_FAIL_ON =            {{ project.robot.report.fail_on|default('None') }}
+REPORT_LABEL =              {% if project.robot.report.use_labels|default(true) %}-l true{% endif %}
+REPORT_PROFILE_OPTS =       {% if project.robot.report.custom_profile %}--profile $(ROBOT_PROFILE){% endif %}
+OBO_FORMAT_OPTIONS =        {{ project.robot.obo_format_options }}
+SPARQL_VALIDATION_CHECKS =  {% for x in project.robot.report.custom_sparql_checks|default(['owldef-self-reference', 'iri-range', 'label-with-iri', 'multiple-replaced_by']) %}{{ x }} {% endfor %}
+SPARQL_EXPORTS =            {% for x in project.robot.report.custom_sparql_exports|default(['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms']) %}{{ x }} {% endfor %}
 ODK_VERSION_MAKEFILE =      {% if env is defined %}{{env['ODK_VERSION'] or "Unknown" }}{% else %}"Unknown"{% endif %}
-RELAX_OPTIONS =             {{ project.robot_relax_options }}
-REDUCE_OPTIONS =            {{ project.robot_reduce_options }}
+RELAX_OPTIONS =             {{ project.robot.relax_options }}
+REDUCE_OPTIONS =            {{ project.robot.reduce_options }}
 
 TODAY ?=                    $(shell date +%Y-%m-%d)
 OBODATE ?=                  $(shell date +'%d:%m:%Y %H:%M')
@@ -150,7 +150,7 @@ all: all_odk
 all_odk: odkversion{% if project.config_hash %} config_check{% endif %} test custom_reports all_assets{% if project.release_diff %} release_diff{% endif %}
 
 .PHONY: test
-test: odkversion validate_idranges {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot_report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
+test: odkversion validate_idranges {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot.report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
 	echo "Finished running all tests successfully."
 
 .PHONY: test
@@ -192,16 +192,16 @@ export ROBOT_PLUGINS_DIRECTORY=$(TMPDIR)/plugins
 .PHONY: custom_robot_plugins
 custom_robot_plugins:
 
-{% if project.robot_plugins is defined %}
+{% if project.robot.plugins is not none %}
 .PHONY: extra_robot_plugins
-extra_robot_plugins: {% for plugin in project.robot_plugins.plugins %} $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar {% endfor %}
+extra_robot_plugins: {% for plugin in project.robot.plugins %} $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar {% endfor %}
 {% endif %}
 
 # Install all ROBOT plugins to the runtime plugins directory
 .PHONY: all_robot_plugins
 all_robot_plugins: $(foreach plugin,$(notdir $(wildcard /tools/robot-plugins/*.jar)),$(ROBOT_PLUGINS_DIRECTORY)/$(plugin)) \
 		   $(foreach plugin,$(notdir $(wildcard ../../plugins/*.jar)),$(ROBOT_PLUGINS_DIRECTORY)/$(plugin)) \
-		   custom_robot_plugins {% if project.robot_plugins is defined %}extra_robot_plugins {% endif %} \
+		   custom_robot_plugins {% if project.robot.plugins is not none %}extra_robot_plugins {% endif %} \
 
 # Default rule to install plugins
 $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
@@ -213,7 +213,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
 	fi
 
 # Specific rules for supplementary plugins defined in configuration
-{% if project.robot_plugins is defined %}{% for plugin in project.robot_plugins.plugins %}
+{% if project.robot.plugins is not none %}{% for plugin in project.robot.plugins %}
 $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar:
 {%- if plugin.mirror_from %}
 	curl -L -o $@ {{ plugin.mirror_from }}
@@ -293,9 +293,9 @@ all_mappings: $(MAPPING_FILES)
 # QC Reports & Utilities
 # ----------------------------------------
 
-OBO_REPORT = {% for x in project.robot_report.report_on|default(["edit"]) %} {% if x=="edit" %}$(SRC){% else %}{{ x }}{% endif %}-obo-report{% endfor %}
-ALIGNMENT_REPORT = {% for x in project.robot_report.report_on|default(["edit"]) %} {% if x =="edit" %}$(SRC){% else %}{{ x }}{% endif %}-align-report{% endfor %}
-REPORTS = $(OBO_REPORT){% if project.robot_report.upper_ontology is defined and project.robot_report.upper_ontology %} $(ALIGNMENT_REPORT){% endif %}
+OBO_REPORT = {% for x in project.robot.report.report_on|default(["edit"]) %} {% if x=="edit" %}$(SRC){% else %}{{ x }}{% endif %}-obo-report{% endfor %}
+ALIGNMENT_REPORT = {% for x in project.robot.report.report_on|default(["edit"]) %} {% if x =="edit" %}$(SRC){% else %}{{ x }}{% endif %}-align-report{% endfor %}
+REPORTS = $(OBO_REPORT){% if project.robot.report.upper_ontology is defined and project.robot.report.upper_ontology %} $(ALIGNMENT_REPORT){% endif %}
 REPORT_FILES = $(patsubst %, $(REPORTDIR)/%.tsv, $(REPORTS))
 
 .PHONY: robot_reports
@@ -326,9 +326,9 @@ validate_profile_%: $(REPORTDIR)/validate_profile_owl2dl_%.txt
 
 SPARQL_VALIDATION_QUERIES = $(foreach V,$(SPARQL_VALIDATION_CHECKS),$(SPARQLDIR)/$(V)-violation.sparql)
 
-sparql_test: {% for x in project.robot_report.sparql_test_on|default(["edit"]) %} {% if x=="edit" %}$(SRCMERGED){% else %}{{ x }}{% endif %}{% endfor %} | $(REPORTDIR)
+sparql_test: {% for x in project.robot.report.sparql_test_on|default(["edit"]) %} {% if x=="edit" %}$(SRCMERGED){% else %}{{ x }}{% endif %}{% endfor %} | $(REPORTDIR)
 ifneq ($(SPARQL_VALIDATION_QUERIES),)
-  {% for x in project.robot_report.sparql_test_on|default(["edit"]) -%}
+  {% for x in project.robot.report.sparql_test_on|default(["edit"]) -%}
   {%- if x=="edit" -%}
   {% set input = "$(SRCMERGED)"%}
   {%- else -%}
@@ -343,16 +343,16 @@ endif
 # ----------------------------------------
 
 $(REPORTDIR)/$(SRC)-obo-report.tsv: $(SRCMERGED) | $(REPORTDIR)
-	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot_report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor -%}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif -%}{% endif -%} --print 5 -o $@
+	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot.report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor -%}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif -%}{% endif -%} --print 5 -o $@
 
 $(REPORTDIR)/%-obo-report.tsv: % | $(REPORTDIR)
-	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot_report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif %}{% endif -%} --print 5 -o $@
-{%- if project.robot_report.upper_ontology is defined and project.robot_report.upper_ontology %}
+	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot.report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif %}{% endif -%} --print 5 -o $@
+{%- if project.robot.report.upper_ontology is defined and project.robot.report.upper_ontology %}
 
 $(REPORTDIR)/$(SRC)-align-report.tsv: $(SRCMERGED) | $(REPORTDIR) all_robot_plugins
 	$(ROBOT) odk:check-align -i $< --reasoner $(REASONER) \
-		 --upper-ontology-iri {{ project.robot_report.upper_ontology }}
-		 {%- if project.robot_report.use_base_iris %} \
+		 --upper-ontology-iri {{ project.robot.report.upper_ontology }}
+		 {%- if project.robot.report.use_base_iris %} \
 		 {% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} \
 		 {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} \
 		 {% endif %}{% else %} \
@@ -360,8 +360,8 @@ $(REPORTDIR)/$(SRC)-align-report.tsv: $(SRCMERGED) | $(REPORTDIR) all_robot_plug
 
 $(REPORTDIR)/%-align-report.tsv: % | $(REPORTDIR) all_robot_plugins
 	$(ROBOT) odk:check-align -i $< --reasoner $(REASONER) \
-		 --upper-ontology-iri {{ project.robot_report.upper_ontology }}
-		 {%- if project.robot_report.use_base_iris %} \
+		 --upper-ontology-iri {{ project.robot.report.upper_ontology }}
+		 {%- if project.robot.report.use_base_iris %} \
 		 {% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} \
 		 {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} \
 		 {% endif %}{% else %} \
@@ -369,7 +369,7 @@ $(REPORTDIR)/%-align-report.tsv: % | $(REPORTDIR) all_robot_plugins
 {%- endif %}
 
 check_for_robot_updates:
-{%- if project.robot_report.custom_profile %}	
+{%- if project.robot.report.custom_profile %}
 	@cut -f2 "/tools/templates/src/ontology/profile.txt" | sort > $(TMPDIR)/sorted_tsv2.txt
 	@cut -f2 "$(ROBOT_PROFILE)" | sort > $(TMPDIR)/sorted_tsv1.txt
 	@comm -23 $(TMPDIR)/sorted_tsv2.txt $(TMPDIR)/sorted_tsv1.txt > $(TMPDIR)/missing.txt
@@ -395,7 +395,7 @@ ASSETS = \
 
 RELEASE_ASSETS = \
   $(MAIN_FILES) {% if project.import_group is defined %}{% if project.import_group.release_imports %}$(IMPORT_FILES) {% endif %}{% endif %}\
-  $(SUBSET_FILES){% if project.robot_report.release_reports %} \
+  $(SUBSET_FILES){% if project.robot.report.release_reports %} \
   $(REPORT_FILES){% endif %}
 
 .PHONY: all_assets


### PR DESCRIPTION
The schema for the ODK configuration file is a bit of a mess.

There are a lot of options directly in the top-level `project` dictionary, about wildly diverse stuff ranging from enabling validation of RDF/XML artefacts to setting the amount of memory allocated to ROBOT to setting the emails to which Travis should send failure reports, etc. That schema would benefit from some reorganisation to make things clearer, e.g. grouping all options related to GitHub in a `github` section and similar.

The problem, of course, is that any attempt at reorganising the schema by renaming or moving options around will unavoidably break existing ODK repositories the next time they try to run `update_repo`, which is a no-go: it must not be necessary for users to manually amend their `-odk.yaml` file when they update from one major version of the ODK to another (unless they _want_ to do that, say to benefit from a new feature that is disabled by default).

So, this PR is intended to experiment a system by which we could make the schema evolve as we see fit, while at all times preserving backwards compatibility with existing ODK configuration files.

The principle is simple. Currently, when we read the configuration file, we do that in two steps: (1) we load the YAML file into a Python dictionary, and (2) we instantiate a `OntologyProject` object from that dictionary.

```python
obj = yaml.load(stream, Loader=yaml.FullLoader)           # (1)
project = from_dict(data_class=OntologyProject, data=obj) # (2)
```

In this PR, we introduce an intermediate preprocessing step:

```python
obj = yaml.load(stream, Loader=yaml.FullLoader)           # (1)
preprocess_config_dict(obj)
project = from_dict(data_class=OntologyProject, data=obj) # (2)
```

The role of the preprocessing step is to transform the YAML dictionary as read from disk to make sure it is conform to what is needed to make a `OntologyProject`.

For example, let’s suppose we decide, in the next ODK version, to rename the `use_base_merging` option in the `import_group` to `merge_base`, because we decide that `merge_base` somehow sounds better (not saying we should do that, this is for the example only!). All we would need to do to preserve compatibility (and so, to make sure that existing files using `use_base_merging` are still accepted) is to declare the following tuple in the `preprocess_config_dict()` method:

```python
('import_group.use_base_merging', 'import_group.merge_base')
```

This will instruct the method to look for a `use_base_merging` key in the `import_group` subdictionary, and if such a key is found, to replace it by a key named `merge_base`.

A new command `update-config` will also give the users the possibility to actively migrate their old config files to the new syntax, should they want to do so (they would not _have_ to, since the compatibility layer ensures that files compliant with the old syntax can still be used).

As a complete example, this PR includes (2nd commit) a partial reorganisation of the schema in which all options related to ROBOT are grouped into a single `robot` section. That is, what currently looks like this in the current schema:

```yaml
reasoner: ELK
...
obo_format_options: --clean-obo 'strict drop-untranslatable-axioms'
...
robot_relax_options: --include-subclass-of true
robot_reduce_options: --include-subproperties true
...
robot_plugins:
  plugins:
    - name: my_plugin
...
robot_report:
  release_reports: True
  fail_on: ERROR
  ...
...
```

now becomes:

```yaml
...
robot:
  reasoner: ELK
  obo_format_options: --clean-obo 'strict drop-untranslatable-axioms'
  relax_options: --include-subclass-of true
  reduce_options: --include-subproperties true
  plugins:
    - name: my_plugin
  report:
    release_reports: True
    fail_on: ERROR
...
```