### PR TITLE
Ignore additional release files.

### DIFF
--- a/template/.gitignore.jinja2
+++ b/template/.gitignore.jinja2
@@ -23,6 +23,10 @@ bin/
 /{{ project.id }}-full.*
 /{{ project.id }}-simple.*
 /{{ project.id }}-simple-non-classified.*
+/mappings/
+/patterns/
+/reports/
+/subsets/
 
 src/ontology/mirror
 src/ontology/mirror/*


### PR DESCRIPTION
Top-level release files are all listed in `.gitignore`, because the default behaviour is _not_ to commit them when the repository is initially seeded (unless the `--commit-artefacts` option is passed to the `seed` command).

For consistency, we should also ignore "additional" release files such as subsets, mapping sets, and reports.

closes #1238