### PR TITLE
Do not allow users to configure ODK directories.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -312,9 +312,6 @@ class SubsetGroup(ProductGroup):
     products : Optional[List[SubsetProduct]] = None
     """all subset products"""
     
-    directory : Directory = "subsets/"
-    """directory where subsets are placed after extraction from ontology"""
-    
     def _add_stub(self, id : OntologyHandle):
         if self.products is None:
             self.products = []
@@ -367,9 +364,6 @@ class ImportGroup(ProductGroup):
 
     strip_annotation_properties: bool = True
     """If set to true, strip away annotation properties from imports, apart from explicitly imported properties and properties listed in annotation_properties."""
-    
-    directory : Directory = "imports/"
-    """directory where imports are extracted into to"""
     
     annotate_defined_by : bool = False
     """If set to true, the annotation rdfs:definedBy is added for each external class. 
@@ -478,9 +472,6 @@ class ComponentGroup(ProductGroup):
     products : Optional[List[ComponentProduct]] = None
     """all component products"""
 
-    directory : Directory = "components"
-    """directory where components are maintained"""
-
     def _add_stub(self, filename : str):
         if self.products is None:
             self.products = []
@@ -510,9 +501,6 @@ class PatternPipelineGroup(ProductGroup):
     matches: Optional[List[PatternPipelineProduct]] = None
     """pipelines specifically configured for matching, NOT generating."""
     
-    directory : Directory = "../patterns/"
-    """directory where pattern source lives, also where TSV exported to"""
-
     def _add_stub(self, id : OntologyHandle):
         if self.products is None:
             self.products = []
@@ -525,8 +513,6 @@ class SSSOMMappingSetGroup(JsonSchemaMixin):
     A configuration section that consists of a list of `SSSOMMappingSetProduct` descriptions
     """
     
-    directory : Directory = "../mappings"
-
     release_mappings : bool = False
     """If set to True, mappings are copied to the release directory."""
 
@@ -566,8 +552,6 @@ class BabelonTranslationSetGroup(JsonSchemaMixin):
     A configuration section that consists of a list of `BabelonTranslationProduct` descriptions
     """
     
-    directory : Directory = "../translations"
-
     release_merged_translations : bool = False
     """If true, a big table and JSON file is created which contains all translations."""
     
@@ -594,9 +578,6 @@ class ExportGroup(ProductGroup):
     
     products : Optional[List[ExportProduct]] = None
     """all export products"""
-
-    directory : Directory = "reports/"
-    """directory where exports are placed"""
 
 
 @dataclass_json

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -57,7 +57,7 @@ SCRIPTSDIR=                 ../scripts
 UPDATEREPODIR=              target
 SPARQLDIR =                 ../sparql
 EXTENDED_PREFIX_MAP=        $(TMPDIR)/obo.epm.json
-COMPONENTSDIR =             {{ project.components.directory|default('components') }}
+COMPONENTSDIR =             components
 {%- if project.robot_report.custom_profile %}
 ROBOT_PROFILE =             profile.txt
 {%- endif %}
@@ -91,7 +91,7 @@ PATTERN_RELEASE_FILES=      $(PATTERNDIR)/definitions.owl $(PATTERNDIR)/pattern.
 {% endif %}
 
 {%- if project.use_mappings %}
-MAPPINGDIR=                 {% if project.sssom_mappingset_group is not none %}{{project.sssom_mappingset_group.directory|default("../mappings")}}{% endif %}
+MAPPINGDIR=                 ../mappings
 MAPPING_TESTER=             sssom validate
 SSSOMPY=                    sssom
 MAPPINGS=                   {% if project.sssom_mappingset_group is not none %}{%- for mapping in project.sssom_mappingset_group.products %}{{ mapping.id }} {% endfor %}{% endif %}
@@ -99,7 +99,7 @@ MAPPING_RELEASE_FILES=      $(foreach n,$(MAPPINGS), $(MAPPINGDIR)/$(n).sssom.ts
 {% endif %}
 
 {%- if project.use_translations %}
-TRANSLATIONSDIR=            {% if project.babelon_translation_group is not none %}{{project.babelon_translation_group.directory|default("../translations")}}{% endif %}
+TRANSLATIONSDIR=            ../translations
 BABELONPY=                  babelon -q
 TRANSLATIONS_OWL=           {%- for translation in project.babelon_translation_group.products %}$(TRANSLATIONSDIR)/{{ translation.id }}.babelon.owl {% if translation.include_robot_template_synonyms %} $(TRANSLATIONSDIR)/{{ translation.id }}.synonyms.owl {% endif %}{% endfor %}
 TRANSLATIONS_TSV=           {%- for translation in project.babelon_translation_group.products %}$(TRANSLATIONSDIR)/{{ translation.id }}-preprocessed.babelon.tsv {% endfor %}


### PR DESCRIPTION
Directories for subsets, imports, components, patterns, mappings, and translations should _not_ be modified by users, and the ODK configuration file should therefore _not_ offer options to do precisely that.

We remove all `directory` options from the ODK configuration model.

closes #1244