### PR TITLE
Preserve non-ODK-managed imports by default.

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -697,7 +697,7 @@ class OntologyProject(JsonSchemaMixin):
     use_custom_import_module : bool = False
     """if true add a custom import module which is managed through a robot template. This can also be used to manage your module seed."""
 
-    preserve_non_odk_managed_imports : bool = False
+    preserve_non_odk_managed_imports : bool = True
     """if true, import declarations that were added independently of the ODK will be preserved when updating the repository."""
     
     custom_makefile_header : str = """


### PR DESCRIPTION
When updating a repository and updating the import declarations in the edit file, by default do _not_ call the `odk:import` command in “exclusive” mode, so that import declarations that do not correspond to an ODK-declared import or component are preserved.