### PR TITLE
Fix test programs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test_odklite_programs:
 	@./tests/test-program.sh JINJANATOR jinjanate --version
 	@./tests/test-program.sh DICER-CLI dicer-cli --version
 	@./tests/test-program.sh SSSOM-CLI sssom-cli --version
-	@./tests/test-program.sh ODK odk.py
+	@./tests/test-program.sh ODK odk.py --help
 
 test_odkfull_programs: test_odklite_programs
 	@./tests/test-program.sh KONCLUDE Konclude -h

--- a/tests/test-program.sh
+++ b/tests/test-program.sh
@@ -5,4 +5,4 @@ ODK_TAG=${ODK_TAG:-latest}
 
 program_name=$1; shift
 echo -n "Checking for $program_name... "
-docker run --rm obolibrary/$ODK_IMAGE:$ODK_TAG $@ >/dev/null && echo OK || echo KO
+docker run --rm obolibrary/$ODK_IMAGE:$ODK_TAG $@ >/dev/null && echo OK || { echo KO ; exit 1 ; }


### PR DESCRIPTION
This PR:

1. updates the test-program.sh script so that it not only prints a “KO” string when the test program cannot be run, but it also exists with a non-zero exit code, so that it makes the `test_odk{full|lite}_programs` target fail.
2. fixes the run test for the `odk.py` script, by invoking it with the `--help` option (without that option, the script still prints out its help message _but_ exists with a non-zero code, which is interpreted as indicating that the script is not runnable).

closes #1258