### PR TITLE
Add dynamic branch names to github actions

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -22,6 +22,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:
+          branch: update-obo-epm-${{ github.run_id }}
           token: ${{ secrets.WORKFLOW_TOKEN }}
           commit-message: Update constraints.txt
           title: 'Update constraints.txt'

--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -23,6 +23,7 @@ jobs:
         if: ${{ success() }}
         with:
           branch: update-constraints
+          delete-branch: true
           token: ${{ secrets.WORKFLOW_TOKEN }}
           commit-message: Update constraints.txt
           title: 'Update constraints.txt'

--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -22,7 +22,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:
-          branch: update-obo-epm-${{ github.run_id }}
+          branch: update-constraints
           token: ${{ secrets.WORKFLOW_TOKEN }}
           commit-message: Update constraints.txt
           title: 'Update constraints.txt'

--- a/.github/workflows/update-epm.yml
+++ b/.github/workflows/update-epm.yml
@@ -21,7 +21,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:
-          branch: update-obo-epm-${{ github.run_id }}
+          branch: update-obo-epm
           commit-message: Update OBO Extended Prefix Map from Bioregistry.
           title: 'Update OBO Extended Prefix Map'
           body: |

--- a/.github/workflows/update-epm.yml
+++ b/.github/workflows/update-epm.yml
@@ -21,6 +21,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         if: ${{ success() }}
         with:
+          branch: update-obo-epm-${{ github.run_id }}
           commit-message: Update OBO Extended Prefix Map from Bioregistry.
           title: 'Update OBO Extended Prefix Map'
           body: |

--- a/.github/workflows/update-epm.yml
+++ b/.github/workflows/update-epm.yml
@@ -22,6 +22,7 @@ jobs:
         if: ${{ success() }}
         with:
           branch: update-obo-epm
+          delete-branch: true
           commit-message: Update OBO Extended Prefix Map from Bioregistry.
           title: 'Update OBO Extended Prefix Map'
           body: |


### PR DESCRIPTION
This is so that the two actions do not overwrite each others branches.

@gouttegd not entirely sure this will work until we test it.