### PR TITLE
Bump the version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v1.7 (TBD)
+
 # v1.6
 
 For more detailed changes see:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ docs:
 	@ODK_IMAGE=odklite ./odk.sh python ./odk/schema_documentation.py
 
 # Building docker image
-VERSION = "v1.6"
+VERSION = "v1.7"
 IM=obolibrary/odkfull
 IMLITE=obolibrary/odklite
 ROB=obolibrary/robot


### PR DESCRIPTION
This PR opens the ODK 1.7 development cycle by bumping the version number and adding the corresponding section in the changelog.

And here we go again!