### PR TITLE
Fix usage instructions for update_repo in template and docs

### DIFF
--- a/docs/ODKDevelopmentSnapshot.md
+++ b/docs/ODKDevelopmentSnapshot.md
@@ -23,14 +23,12 @@ If you want to use the development snapshot with your `run.sh` docker wrapper, y
 
 1. `docker pull obolibrary/odkfull:dev` As mentioned above, this command installs the development snapshot
 1. `docker pull obolibrary/odkfull`
-1. Make sure your repo is up to date with the latest official release version (at least 1.3.1)
-1. If currently using 1.3.1: `IMAGE=odkfull:dev sh run.sh make update_repo`, else `ODK_TAG=dev sh run.sh make update_repo`
-1. `ODK_TAG=dev sh run.sh make update_repo` (again, if you ran it above)
+1. Make sure your repo is up to date with the latest official release version (at least 1.6)
+1. Run `ODK_TAG=dev sh run.sh update_repo` 2x.
 
 You have now set your repo up to run via the development snapshot. At the top of the file, in the comments, your automatically-generated src/ontology/Makefile should now reference the development snapshot you have installed rather than the stable production release.
 
 **Finally:**
 
 5. You can now run any command via the `run.sh` docker wrapper. Just make sure you use the appropriate prefix depending on your version of the ODK:
-- If you are using ODK 1.3.1 run `IMAGE=obolibrary/odkfull:dev sh run.sh make update_repo` (or whatever other command you wanted to run).
-- If you are using ODK 1.3.2 or later (or the `dev` image), run: `ODK_TAG=dev sh run.sh make update_repo` (or whatever other command you wanted to run).
+- If you are using ODK >= 1.6 run `ODK_TAG=dev sh run.sh update_repo` (or whatever other command you wanted to run).

--- a/template/_dynamic_documentation.jinja2
+++ b/template/_dynamic_documentation.jinja2
@@ -256,7 +256,7 @@ Your ODK repositories configuration is managed in `src/ontology/{{ project.id }}
 
 
 ```
-sh run.sh make update_repo
+sh run.sh update_repo
 ```
 
 There are a large number of options that can be set to configure your ODK, but we will only discuss a few of them here.
@@ -419,7 +419,7 @@ components:
     - filename: mycomp.owl
 ```
 
-When running `sh run.sh make update_repo`, a new file `src/ontology/components/mycomp.owl` will 
+When running `sh run.sh update_repo`, a new file `src/ontology/components/mycomp.owl` will 
 be created which you can edit as you see fit. Typical ways to edit:
 
 1. Using a ROBOT template to generate the component (see below)
@@ -819,7 +819,7 @@ We can define custom checks using [SPARQL](https://www.w3.org/TR/rdf-sparql-quer
 3. Update the repository so your new SPARQL check will be included in the QC.
 
 ```shell
-sh run.sh make update_repo
+sh run.sh update_repo
 ```
 {%   if project.use_dosdps -%}
 ^^^ docs/templates/dosdp.md

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -176,7 +176,7 @@ odkversion:
 config_check:
 	@if [ "$$(tr -d '\r' < $(ONT)-odk.yaml | sha256sum | cut -c1-64)" = "$(CONFIG_HASH)" ]; then \
 		echo "Repository is up-to-date." ; else \
-		echo "Your ODK configuration has changed since this Makefile was generated. You may need to run 'make update_repo'." ; fi
+		echo "Your ODK configuration has changed since this Makefile was generated. You may need to run 'sh run.sh update_repo'." ; fi
 {% endif %}
 
 $(TMPDIR) $(REPORTDIR) $(MIRRORDIR) $(IMPORTDIR) $(COMPONENTSDIR) $(SUBSETDIR):

--- a/template/src/ontology/README-editors.md.jinja2
+++ b/template/src/ontology/README-editors.md.jinja2
@@ -17,11 +17,11 @@ documentation:
 to your Makefile and running:
 
 ```
-sh run.sh make update_repo
+sh run.sh update_repo
 ```
 (Unix)
 
 ```
-run.bat make update_repo
+run.bat update_repo
 ```
 (Windows)


### PR DESCRIPTION
The docs still reflected the old way to update_repo using `make`. This commit makes sure `update_repo` is used correctly without `make`.