### PR TITLE
Allow changing the configuration schema transparently for users

### DIFF
--- a/odk/odk.py
+++ b/odk/odk.py
@@ -596,13 +596,29 @@ class RobotPlugin(JsonSchemaMixin):
 
 @dataclass_json
 @dataclass
-class PluginsGroup(JsonSchemaMixin):
+class RobotOptionsGroup(JsonSchemaMixin):
     """
-    A configuration section to list extra ROBOT plugins not provided by the ODK
+    A configuration section for additional options specific to ROBOT.
     """
 
+    reasoner : str = "ELK"
+    """Reasoner to use in robot commands that need one."""
+
+    obo_format_options : str = ""
+    """Additional options to pass to robot convert when exporting to OBO. Default is '--clean-obo "strict drop-untranslatable-axioms"'."""
+
+    relax_options : str = "--include-subclass-of true"
+    """Additional options to pass to robot relax command."""
+
+    reduce_options : str = "--include-subproperties true"
+    """Additional options to pass to robot reduce command."""
+
     plugins : Optional[List[RobotPlugin]] = None
-    """The list of plugins to use"""
+    """List of ROBOT plugins used by this project."""
+
+    report : Dict[str, Any] = field(default_factory=lambda: ReportConfig().to_dict())
+    """Settings for ROBOT report, ROBOT verify and additional reports that are generated."""
+
 
     
 @dataclass_json
@@ -663,9 +679,6 @@ class OntologyProject(JsonSchemaMixin):
     
     export_project_yaml: bool = False
     """Flag to set if you want a full project.yaml to be exported, including all the default options."""
-    
-    reasoner : str = "ELK"
-    """Name of reasoner to use in ontology pipeline, see robot reason docs for allowed values"""
     
     exclude_tautologies : str = "structural"
     """Remove tautologies such as A SubClassOf: owl:Thing or owl:Nothing SubclassOf: A. For more information see http://robot.obolibrary.org/reason#excluding-tautologies"""
@@ -771,15 +784,6 @@ class OntologyProject(JsonSchemaMixin):
     travis_emails : Optional[List[Email]] = None ## ['obo-ci-reports-all@groups.io']
     """Emails to use in travis configurations. """
     
-    obo_format_options : str = ""
-    """Additional args to pass to robot when saving to obo. The default is '--clean-obo "strict drop-untranslatable-axioms"'."""
-
-    robot_relax_options : str = "--include-subclass-of true"
-    """Additional options to pass to robot's relax command."""
-
-    robot_reduce_options : str = "--include-subproperties true"
-    """Additional options to pass to robot's reduce command."""
-
     catalog_file : str = "catalog-v001.xml"
     """Name of the catalog file to be used by the build."""
 
@@ -798,17 +802,14 @@ class OntologyProject(JsonSchemaMixin):
     contributors : Optional[List[Person]] = None
     """List of ontology contributors (currently setting this has no effect)"""
 
-    robot_report : Dict[str, Any] = field(default_factory=lambda: ReportConfig().to_dict())
-    """Block that includes settings for ROBOT report, ROBOT verify and additional reports that are generated"""
-
     ensure_valid_rdfxml : bool = True
     """When enabled, ensure that any RDF/XML product file is valid"""
 
     extra_rdfxml_checks : bool = False
     """When enabled, RDF/XML product files are checked against additional parsers"""
 
-    robot_plugins : Optional[PluginsGroup] = None
-    """Block that includes information on the extra ROBOT plugins used by this project"""
+    robot : RobotOptionsGroup = field(default_factory=lambda: RobotOptionsGroup())
+    """Block for ROBOT-related options"""
 
     # product groups
     import_group : Optional[ImportGroup] = None
@@ -855,10 +856,10 @@ class OntologyProject(JsonSchemaMixin):
         if self.components is not None:
             self.components.fill_missing(self)
 
-        if not '--clean-obo' in self.obo_format_options:
-            if len(self.obo_format_options) > 0:
-                self.obo_format_options += ' '
-            self.obo_format_options += '--clean-obo "strict drop-untranslatable-axioms"'
+        if not '--clean-obo' in self.robot.obo_format_options:
+            if len(self.robot.obo_format_options) > 0:
+                self.robot.obo_format_options += ' '
+            self.robot.obo_format_options += '--clean-obo "strict drop-untranslatable-axioms"'
 
 @dataclass
 class ExecutionContext(JsonSchemaMixin):
@@ -938,7 +939,13 @@ def update_config_dict(obj):
     """
     changes = [
             # old key path               new key path
-            ('example.old.key',         'example.new.key')
+            ('reasoner',                'robot.reasoner'),
+            ('obo_format_options',      'robot.obo_format_options'),
+            ('relax_options',           'robot.relax_options'),
+            ('reduce_options',          'robot.reduce_options'),
+            ('robot_plugins.plugins',   'robot.plugins'),
+            ('robot_plugins',           None),
+            ('robot_report',            'robot.report'),
             ]
     for old, new in changes:
         v = pop_key(obj, old)
@@ -1435,7 +1442,7 @@ def update(templatedir):
                 policies.append(('.github/workflows/' + workflow + '.yml', ALWAYS))
         if project.documentation is not None and 'docs' in project.workflows:
             policies.append(('.github/workflows/docs.yml', ALWAYS))
-    if not project.robot_report.get('custom_profile', False):
+    if not project.robot.report.get('custom_profile', False):
         policies.append(('src/ontology/profile.txt', NEVER))
 
     # Proceed with template instantiation, using the policies
@@ -1523,7 +1530,7 @@ def seed(config, clean, outdir, templatedir, dependencies, title, user, source, 
         logging.info("No templates folder in /tools/; assume not in docker context")
         templatedir = "./template"
     policies = []
-    if not project.robot_report.get('custom_profile', False):
+    if not project.robot.report.get('custom_profile', False):
         policies.append(('src/ontology/profile.txt', NEVER))
     tgts += install_template_files(mg, templatedir, outdir, policies)
 

--- a/template/_dynamic_documentation.jinja2
+++ b/template/_dynamic_documentation.jinja2
@@ -802,19 +802,20 @@ We can define custom checks using [SPARQL](https://www.w3.org/TR/rdf-sparql-quer
 
 1. Add the SPARQL query in `src/sparql`. The name of the file should end with `-violation.sparql`. Please give a name that helps to understand which violation the query wants to check.
 2. Add the name of the new file to odk configuration file `src/ontology/uberon-odk.yaml`:
-    1. Include the name of the file (without the `-violation.sparql` part) to the list inside the key `custom_sparql_checks` that is inside `robot_report` key.
-    1. If the `robot_report` or `custom_sparql_checks` keys are not available, please add this code block to the end of the file.
+    1. Include the name of the file (without the `-violation.sparql` part) to the list inside the key `custom_sparql_checks` that is inside `robot.report` key.
+    1. If the `robot.report` or `custom_sparql_checks` keys are not available, please add this code block to the end of the file.
 
         ``` yaml
-          robot_report:
-            release_reports: False
-            fail_on: ERROR
-            use_labels: False
-            custom_profile: True
-            report_on:
-              - edit
-            custom_sparql_checks:
-              - name-of-the-file-check
+          robot:
+            report:
+              release_reports: False
+              fail_on: ERROR
+              use_labels: False
+              custom_profile: True
+              report_on:
+                - edit
+              custom_sparql_checks:
+                - name-of-the-file-check
         ```
 3. Update the repository so your new SPARQL check will be included in the QC.
 

--- a/template/_dynamic_sparql.jinja2
+++ b/template/_dynamic_sparql.jinja2
@@ -17,7 +17,7 @@ WHERE {
 {#
     SPARQL QUERY QC checks
 -#}
-{% if project.robot_report.custom_sparql_checks is not defined or 'owldef-self-reference' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'owldef-self-reference' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/owldef-self-reference-violation.sparql
 PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
@@ -31,7 +31,7 @@ SELECT ?term WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'redundant-subClassOf' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'redundant-subClassOf' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/redundant-subClassOf-violation.sparql
 PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -48,7 +48,7 @@ SELECT ?term ?xl ?y ?yl ?z ?zl WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'taxon-range' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'taxon-range' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/taxon-range-violation.sparql
 PREFIX never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
 PREFIX present_in_taxon: <http://purl.obolibrary.org/obo/RO_0002175>
@@ -61,7 +61,7 @@ WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'iri-range' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'iri-range' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/iri-range-violation.sparql
 PREFIX never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
 PREFIX present_in_taxon: <http://purl.obolibrary.org/obo/RO_0002175>
@@ -82,7 +82,7 @@ WHERE {
   FILTER (!isIRI(?value))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'iri-range-advanced' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'iri-range-advanced' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/iri-range-advanced-violation.sparql
 PREFIX never_in_taxon: <http://purl.obolibrary.org/obo/RO_0002161>
 PREFIX present_in_taxon: <http://purl.obolibrary.org/obo/RO_0002175>
@@ -105,7 +105,7 @@ WHERE {
   FILTER (!isIRI(?value))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'label-with-iri' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'label-with-iri' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/label-with-iri-violation.sparql
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
@@ -116,7 +116,7 @@ WHERE {
   FILTER(isIRI(?term) && ({% if project.namespaces %}{% for ns in project.namespaces %}STRSTARTS(str(?term), "{{ ns }}"){% if not loop.last %} || {% endif %}{% endfor %}{% else %}STRSTARTS(str(?term), "{{ project.uribase }}/{{ project.id.upper() }}_"){% endif %}))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'multiple-replaced_by' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'multiple-replaced_by' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/multiple-replaced_by-violation.sparql
 PREFIX replaced_by: <http://purl.obolibrary.org/obo/IAO_0100001>
 
@@ -130,7 +130,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   BIND(CONCAT(str(?value1), CONCAT("|", str(?value2))) as ?value)
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'term-tracker-uri' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'term-tracker-uri' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/term-tracker-uri-violation.sparql
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX term_tracker_item: <http://purl.obolibrary.org/obo/IAO_0000233>
@@ -141,7 +141,7 @@ SELECT ?term ?term_tracker ?term_tracker_type WHERE {
   BIND(DATATYPE(?term_tracker) as ?term_tracker_type) 
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'illegal-date' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'illegal-date' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/illegal-date-violation.sparql
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -155,7 +155,7 @@ SELECT DISTINCT ?term ?property ?value WHERE
   FILTER (datatype(?value) != xsd:dateTime || !regex(str(?value), '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z'))
 }
 {% endif -%}
-{% if project.robot_report.custom_sparql_checks is not defined or 'dc-properties' in project.robot_report.custom_sparql_checks -%}
+{% if project.robot.report.custom_sparql_checks is not defined or 'dc-properties' in project.robot.report.custom_sparql_checks -%}
 ^^^ src/sparql/dc-properties-violation.sparql
 # The purpose of this violation is to make sure people update
 # from using the deprecated DC Elements 1.1 namespace (http://purl.org/dc/elements/1.1/)

--- a/template/src/ontology/Makefile.jinja2
+++ b/template/src/ontology/Makefile.jinja2
@@ -39,7 +39,7 @@ CATALOG=                    {{ project.catalog_file }}
 CONTEXT_FILE =              config/context.json
 {% endif -%}
 ROBOT=                      robot --catalog $(CATALOG){% if project.use_context %} --add-prefixes $(CONTEXT_FILE){% endif %}
-REASONER=                   {{ project.reasoner }}
+REASONER=                   {{ project.robot.reasoner }}
 {# Kept for backwards compatibility with existing custom Makefiles -#}
 {% if project.owltools_memory|length -%}
 OWLTOOLS_MEMORY =           {{ project.owltools_memory }}
@@ -58,18 +58,18 @@ UPDATEREPODIR=              target
 SPARQLDIR =                 ../sparql
 EXTENDED_PREFIX_MAP=        $(TMPDIR)/obo.epm.json
 COMPONENTSDIR =             components
-{%- if project.robot_report.custom_profile %}
+{%- if project.robot.report.custom_profile %}
 ROBOT_PROFILE =             profile.txt
 {%- endif %}
-REPORT_FAIL_ON =            {{ project.robot_report.fail_on|default('None') }}
-REPORT_LABEL =              {% if project.robot_report.use_labels|default(true) %}-l true{% endif %}
-REPORT_PROFILE_OPTS =       {% if project.robot_report.custom_profile %}--profile $(ROBOT_PROFILE){% endif %}
-OBO_FORMAT_OPTIONS =        {{ project.obo_format_options }}
-SPARQL_VALIDATION_CHECKS =  {% for x in project.robot_report.custom_sparql_checks|default(['owldef-self-reference', 'iri-range', 'label-with-iri', 'multiple-replaced_by']) %}{{ x }} {% endfor %}
-SPARQL_EXPORTS =            {% for x in project.robot_report.custom_sparql_exports|default(['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms']) %}{{ x }} {% endfor %}
+REPORT_FAIL_ON =            {{ project.robot.report.fail_on|default('None') }}
+REPORT_LABEL =              {% if project.robot.report.use_labels|default(true) %}-l true{% endif %}
+REPORT_PROFILE_OPTS =       {% if project.robot.report.custom_profile %}--profile $(ROBOT_PROFILE){% endif %}
+OBO_FORMAT_OPTIONS =        {{ project.robot.obo_format_options }}
+SPARQL_VALIDATION_CHECKS =  {% for x in project.robot.report.custom_sparql_checks|default(['owldef-self-reference', 'iri-range', 'label-with-iri', 'multiple-replaced_by']) %}{{ x }} {% endfor %}
+SPARQL_EXPORTS =            {% for x in project.robot.report.custom_sparql_exports|default(['basic-report', 'class-count-by-prefix', 'edges', 'xrefs', 'obsoletes', 'synonyms']) %}{{ x }} {% endfor %}
 ODK_VERSION_MAKEFILE =      {% if env is defined %}{{env['ODK_VERSION'] or "Unknown" }}{% else %}"Unknown"{% endif %}
-RELAX_OPTIONS =             {{ project.robot_relax_options }}
-REDUCE_OPTIONS =            {{ project.robot_reduce_options }}
+RELAX_OPTIONS =             {{ project.robot.relax_options }}
+REDUCE_OPTIONS =            {{ project.robot.reduce_options }}
 
 TODAY ?=                    $(shell date +%Y-%m-%d)
 OBODATE ?=                  $(shell date +'%d:%m:%Y %H:%M')
@@ -151,7 +151,7 @@ all: all_odk
 all_odk: odkversion{% if project.config_hash %} config_check{% endif %} test custom_reports all_assets{% if project.release_diff %} release_diff{% endif %}
 
 .PHONY: test
-test: odkversion validate_idranges {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot_report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
+test: odkversion validate_idranges {% if project.use_dosdps %}dosdp_validation {% endif %}reason_test sparql_test robot_reports {% if project.robot.report.ensure_owl2dl_profile|default(true) %}$(REPORTDIR)/validate_profile_owl2dl_$(ONT).owl.txt{% endif %}
 	echo "Finished running all tests successfully."
 
 .PHONY: test
@@ -193,16 +193,16 @@ export ROBOT_PLUGINS_DIRECTORY=$(TMPDIR)/plugins
 .PHONY: custom_robot_plugins
 custom_robot_plugins:
 
-{% if project.robot_plugins is defined %}
+{% if project.robot.plugins is not none %}
 .PHONY: extra_robot_plugins
-extra_robot_plugins: {% for plugin in project.robot_plugins.plugins %} $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar {% endfor %}
+extra_robot_plugins: {% for plugin in project.robot.plugins %} $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar {% endfor %}
 {% endif %}
 
 # Install all ROBOT plugins to the runtime plugins directory
 .PHONY: all_robot_plugins
 all_robot_plugins: $(foreach plugin,$(notdir $(wildcard /tools/robot-plugins/*.jar)),$(ROBOT_PLUGINS_DIRECTORY)/$(plugin)) \
 		   $(foreach plugin,$(notdir $(wildcard ../../plugins/*.jar)),$(ROBOT_PLUGINS_DIRECTORY)/$(plugin)) \
-		   custom_robot_plugins {% if project.robot_plugins is defined %}extra_robot_plugins {% endif %} \
+		   custom_robot_plugins {% if project.robot.plugins is not none %}extra_robot_plugins {% endif %} \
 
 # Default rule to install plugins
 $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
@@ -214,7 +214,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/%.jar:
 	fi
 
 # Specific rules for supplementary plugins defined in configuration
-{% if project.robot_plugins is defined %}{% for plugin in project.robot_plugins.plugins %}
+{% if project.robot.plugins is not none %}{% for plugin in project.robot.plugins %}
 $(ROBOT_PLUGINS_DIRECTORY)/{{ plugin.name }}.jar:
 {%- if plugin.mirror_from %}
 	curl -L -o $@ {{ plugin.mirror_from }}
@@ -294,9 +294,9 @@ all_mappings: $(MAPPING_FILES)
 # QC Reports & Utilities
 # ----------------------------------------
 
-OBO_REPORT = {% for x in project.robot_report.report_on|default(["edit"]) %} {% if x=="edit" %}$(SRC){% else %}{{ x }}{% endif %}-obo-report{% endfor %}
-ALIGNMENT_REPORT = {% for x in project.robot_report.report_on|default(["edit"]) %} {% if x =="edit" %}$(SRC){% else %}{{ x }}{% endif %}-align-report{% endfor %}
-REPORTS = $(OBO_REPORT){% if project.robot_report.upper_ontology is defined and project.robot_report.upper_ontology %} $(ALIGNMENT_REPORT){% endif %}
+OBO_REPORT = {% for x in project.robot.report.report_on|default(["edit"]) %} {% if x=="edit" %}$(SRC){% else %}{{ x }}{% endif %}-obo-report{% endfor %}
+ALIGNMENT_REPORT = {% for x in project.robot.report.report_on|default(["edit"]) %} {% if x =="edit" %}$(SRC){% else %}{{ x }}{% endif %}-align-report{% endfor %}
+REPORTS = $(OBO_REPORT){% if project.robot.report.upper_ontology is defined and project.robot.report.upper_ontology %} $(ALIGNMENT_REPORT){% endif %}
 REPORT_FILES = $(patsubst %, $(REPORTDIR)/%.tsv, $(REPORTS))
 
 .PHONY: robot_reports
@@ -327,9 +327,9 @@ validate_profile_%: $(REPORTDIR)/validate_profile_owl2dl_%.txt
 
 SPARQL_VALIDATION_QUERIES = $(foreach V,$(SPARQL_VALIDATION_CHECKS),$(SPARQLDIR)/$(V)-violation.sparql)
 
-sparql_test: {% for x in project.robot_report.sparql_test_on|default(["edit"]) %} {% if x=="edit" %}$(SRCMERGED){% else %}{{ x }}{% endif %}{% endfor %} | $(REPORTDIR)
+sparql_test: {% for x in project.robot.report.sparql_test_on|default(["edit"]) %} {% if x=="edit" %}$(SRCMERGED){% else %}{{ x }}{% endif %}{% endfor %} | $(REPORTDIR)
 ifneq ($(SPARQL_VALIDATION_QUERIES),)
-  {% for x in project.robot_report.sparql_test_on|default(["edit"]) -%}
+  {% for x in project.robot.report.sparql_test_on|default(["edit"]) -%}
   {%- if x=="edit" -%}
   {% set input = "$(SRCMERGED)"%}
   {%- else -%}
@@ -344,16 +344,16 @@ endif
 # ----------------------------------------
 
 $(REPORTDIR)/$(SRC)-obo-report.tsv: $(SRCMERGED) | $(REPORTDIR)
-	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot_report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor -%}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif -%}{% endif -%} --print 5 -o $@
+	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot.report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor -%}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif -%}{% endif -%} --print 5 -o $@
 
 $(REPORTDIR)/%-obo-report.tsv: % | $(REPORTDIR)
-	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot_report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif %}{% endif -%} --print 5 -o $@
-{%- if project.robot_report.upper_ontology is defined and project.robot_report.upper_ontology %}
+	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) {% if project.robot.report.use_base_iris %}{% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} {% endif %}{% endif -%} --print 5 -o $@
+{%- if project.robot.report.upper_ontology is defined and project.robot.report.upper_ontology %}
 
 $(REPORTDIR)/$(SRC)-align-report.tsv: $(SRCMERGED) | $(REPORTDIR) all_robot_plugins
 	$(ROBOT) odk:check-align -i $< --reasoner $(REASONER) \
-		 --upper-ontology-iri {{ project.robot_report.upper_ontology }}
-		 {%- if project.robot_report.use_base_iris %} \
+		 --upper-ontology-iri {{ project.robot.report.upper_ontology }}
+		 {%- if project.robot.report.use_base_iris %} \
 		 {% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} \
 		 {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} \
 		 {% endif %}{% else %} \
@@ -361,8 +361,8 @@ $(REPORTDIR)/$(SRC)-align-report.tsv: $(SRCMERGED) | $(REPORTDIR) all_robot_plug
 
 $(REPORTDIR)/%-align-report.tsv: % | $(REPORTDIR) all_robot_plugins
 	$(ROBOT) odk:check-align -i $< --reasoner $(REASONER) \
-		 --upper-ontology-iri {{ project.robot_report.upper_ontology }}
-		 {%- if project.robot_report.use_base_iris %} \
+		 --upper-ontology-iri {{ project.robot.report.upper_ontology }}
+		 {%- if project.robot.report.use_base_iris %} \
 		 {% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} \
 		 {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} \
 		 {% endif %}{% else %} \
@@ -370,7 +370,7 @@ $(REPORTDIR)/%-align-report.tsv: % | $(REPORTDIR) all_robot_plugins
 {%- endif %}
 
 check_for_robot_updates:
-{%- if project.robot_report.custom_profile %}	
+{%- if project.robot.report.custom_profile %}
 	@cut -f2 "/tools/templates/src/ontology/profile.txt" | sort > $(TMPDIR)/sorted_tsv2.txt
 	@cut -f2 "$(ROBOT_PROFILE)" | sort > $(TMPDIR)/sorted_tsv1.txt
 	@comm -23 $(TMPDIR)/sorted_tsv2.txt $(TMPDIR)/sorted_tsv1.txt > $(TMPDIR)/missing.txt
@@ -403,7 +403,7 @@ ASSETS = \
    are in this src/ontology directory". -#}
 RELEASE_ASSETS = \
   $(MAIN_FILES) {% if project.import_group is defined %}{% if project.import_group.release_imports %}$(IMPORT_FILES) {% endif %}{% endif %}\
-  $(SUBSET_FILES){% if project.robot_report.release_reports %} \
+  $(SUBSET_FILES){% if project.robot.report.release_reports %} \
   $(REPORT_FILES){% endif %}
 
 .PHONY: all_assets


### PR DESCRIPTION
This PR implements the system envisioned in #1286 to allow us (ODK developers) to reorganise the ODK configuration schema to (hopefully) make it clearer, all the while allowing users to keep using their existing configuration files.

The first commit implements the actual configuration update mechanism (the `update_config_dict` method in `odk/odk.py`).

The second commit is a proof-of-concept in which we regroup some of the ROBOT-related options, that are currently dispersed in the top-level dictionary, into a new `robot` section.