### PR TITLE
Avoid here-string in run.sh.

### DIFF
--- a/template/src/ontology/run.sh.jinja2
+++ b/template/src/ontology/run.sh.jinja2
@@ -77,7 +77,7 @@ ODK_TAG=${ODK_TAG:-latest}
 ODK_JAVA_OPTS=${ODK_JAVA_OPTS:-{{ project.robot_java_args }}}
 {% else %}
 if [ -z "$USE_SINGULARITY" ]; then
-    {% raw %}DEFAULT_MAX_MEM=$(bc <<<"($(docker info --format={{.MemTotal}}) * .9) / (1024*1024*1024)")G{% endraw %}
+    {% raw %}DEFAULT_MAX_MEM=$(echo "($(docker info --format={{.MemTotal}}) * .9) / (1024*1024*1024)" | bc)G{% endraw %}
 else
     DEFAULT_MAX_MEM=8G
 fi


### PR DESCRIPTION
This PR updates the `src/ontology/run.sh` template to avoid the use of a here-string, which not all shells support (this is not really a bash-ism as here-strings are supported by many shells beyond Bash, but it’s not a POSIX thing either).

closes #1301