### PR TITLE
Standardize all Java launchers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,13 +79,13 @@ RUN test "x$TARGETARCH" = xamd64 && ( \
 
 # Install OWLTOOLS.
 RUN wget -nv https://github.com/owlcollab/owltools/releases/download/$OWLTOOLS_VERSION/owltools \
-        -O /odk/bin/owltools && \
-    wget -nv https://github.com/owlcollab/owltools/releases/download/$OWLTOOLS_VERSION/owltools-oort-all.jar \
-        -O /odk/tools/owltools-oort-all.jar && \
+        -O /odk/tools/owltools.jar && \
+    echo "#!/bin/sh" > /odk/bin/owltools && \
+    echo "exec java \$JAVA_OPTS -DentityExpansionLimit=4086000 -Djava.awt.headless=true -jar /odk/tools/owltools.jar \"\$@\"" >> /odk/bin/owltools && \
     echo "#!/bin/sh" > /odk/bin/ontology-release-runner && \
-    echo "exec java -jar /odk/tools/owltools-oort-all.jar \"\$@\"" >> /odk/bin/ontology-release-runner && \
-    chmod +x /odk/bin/owltools && \
-    chmod +x /odk/bin/ontology-release-runner
+    echo "exec java \$JAVA_OPTS -cp /odk/tools/owltools.jar owltools.ontologyrelease.OboOntologyReleaseRunner \"\$@\"" >> /odk/bin/ontology-release-runner && \
+    chmod 755 /odk/bin/owltools && \
+    chmod 755 /odk/bin/ontology-release-runner
 
 # Install Jena.
 RUN wget -nv http://archive.apache.org/dist/jena/binaries/apache-jena-$JENA_VERSION.tar.gz -O- | tar xzC /odk/tools && \
@@ -96,7 +96,7 @@ RUN wget -nv http://archive.apache.org/dist/jena/binaries/apache-jena-$JENA_VERS
 RUN wget -nv https://github.com/VirtusLab/scala-cli/releases/download/v$SCALA_CLI_VERSION/scala-cli.jar \
         -O /odk/tools/scala-cli.jar && \
     echo "#!/bin/sh" > /odk/bin/scala-cli && \
-    echo "exec java -jar /odk/tools/scala-cli.jar \"\$@\"" >> /odk/bin/scala-cli && \
+    echo "exec java \$JAVA_OPTS -jar /odk/tools/scala-cli.jar \"\$@\"" >> /odk/bin/scala-cli && \
     chmod 0755 /odk/bin/scala-cli
 
 # Install obographviz

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PLATFORMS=linux/amd64,linux/arm64
 
 test_odklite_programs:
 	@./tests/test-program.sh ROBOT robot --version
-	@./tests/test-program.sh DOSDP-TOOLS dosdp-tools -v
+	@./tests/test-program.sh DOSDP-TOOLS dosdp-tools --version
 	@./tests/test-program.sh DICER-CLI dicer-cli --version
 	@./tests/test-program.sh SSSOM-CLI sssom-cli --version
 	@./tests/test-program.sh ODK odk --help

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -49,7 +49,7 @@ RUN mkdir -p /odk/tools /odk/resources/robot/plugins /odk/bin
 RUN wget -nv $ROBOT_JAR \
         -O /odk/tools/robot.jar && \
     echo "#!/bin/sh" > /odk/bin/robot && \
-    echo "exec java \$ROBOT_JAVA_ARGS -jar /odk/tools/robot.jar \"\$@\"" >> /odk/bin/robot && \
+    echo "exec java \$JAVA_OPTS -jar /odk/tools/robot.jar \"\$@\"" >> /odk/bin/robot && \
     chmod 755 /odk/bin/robot && \
     wget -nv https://raw.githubusercontent.com/ontodev/robot/v$ROBOT_VERSION/robot-core/src/main/resources/report_profile.txt \
         -O /odk/resources/robot/profile.txt
@@ -57,9 +57,15 @@ RUN wget -nv $ROBOT_JAR \
 # Install DOSDPTOOLS.
 RUN wget -nv https://github.com/INCATools/dosdp-tools/releases/download/v$DOSDP_VERSION/dosdp-tools-$DOSDP_VERSION.tgz && \
     tar zxf dosdp-tools-$DOSDP_VERSION.tgz && \
-    rm dosdp-tools-$DOSDP_VERSION.tgz && \
-    mv dosdp-tools-$DOSDP_VERSION /odk/tools/dosdptools && \
-    ln -s /odk/tools/dosdptools/bin/dosdp-tools /odk/bin/dosdp-tools && \
+    mv dosdp-tools-$DOSDP_VERSION/lib /odk/tools/dosdp-tools && \
+    rm -rf dosdp-tools-$DOSDP_VERSION dosdp-tools-$DOSDP_VERSION.tgz && \
+    echo "#!/bin/sh" > /odk/bin/dosdp-tools && \
+    echo -n "exec java \$JAVA_OPTS -cp \"" >> /odk/bin/dosdp-tools && \
+    ls /odk/tools/dosdp-tools | while read jar ; do \
+        echo "/odk/tools/dosdp-tools/$jar" ; \
+    done | tr '\n' ':' >> /odk/bin/dosdp-tools && \
+    echo "\" org.monarchinitiative.dosdp.cli.Main \"\$@\"" >> /odk/bin/dosdp-tools && \
+    chmod 755 /odk/bin/dosdp-tools && \
     wget -nv --no-check-certificate https://raw.githubusercontent.com/INCATools/dead_simple_owl_design_patterns/master/src/simple_pattern_tester.py \
         -O /odk/bin/simple_pattern_tester.py && \
     chmod 755 /odk/bin/simple_pattern_tester.py
@@ -75,9 +81,15 @@ RUN wget -nv -O /odk/resources/robot/plugins/sssom.jar https://github.com/goutte
 # Install relation-graph
 RUN wget -nv https://github.com/balhoff/relation-graph/releases/download/v$RELATION_GRAPH/relation-graph-cli-$RELATION_GRAPH.tgz && \
     tar -zxvf relation-graph-cli-$RELATION_GRAPH.tgz && \
-    rm relation-graph-cli-$RELATION_GRAPH.tgz && \
-    mv relation-graph-cli-$RELATION_GRAPH /odk/tools/relation-graph && \
-    ln -s /odk/tools/relation-graph/bin/relation-graph /odk/bin/relation-graph
+    mv relation-graph-cli-$RELATION_GRAPH/lib /odk/tools/relation-graph && \
+    rm -rf relation-graph-cli-$RELATION_GRAPH relation-graph-cli-$RELATION_GRAPH.tgz && \
+    echo "#!/bin/sh" > /odk/bin/relation-graph && \
+    echo -n "exec java \$JAVA_OPTS -cp \"" >> /odk/bin/relation-graph && \
+    ls /odk/tools/relation-graph | while read jar ; do \
+        echo "/odk/tools/relation-graph/$jar" ; \
+    done | tr '\n' ':' >> /odk/bin/relation-graph && \
+    echo "\" org.renci.relationgraph.Main \"\$@\"" >> /odk/bin/relation-graph && \
+    chmod 755 /odk/bin/relation-graph
 
 # Install the Dicer CLI tool
 RUN wget -nv https://github.com/gouttegd/dicer/releases/download/dicer-$DICER_VERSION/dicer-cli \


### PR DESCRIPTION
This PR implements the idea proposed in #1308: it replaces the original launcher scripts for Java-based applications, that are provided by their respective upstream projects, by custom, ODK-specific launcher scripts.

There are two reasons for such a replacement:

(1) Our custom scripts can be much simpler than the upstream-provided scripts, since they are only need to work in the context of the ODK image, where we already know everything we need to know for the applications to run. By contrast, the upstream scripts are intended to run on a variety of systems, where they have to figure out a lot of informations (such as the location of the Jar files or of the JRE) at runtime.

(2) This allows us to use a single environment variable (`JAVA_OPTS`) to pass extra Java options for all those applications.

closes #1308