### PR TITLE
Test running the workflows on all supported systems.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build the images
         run: make build
       - name: Export the ODKFull image to an archiv
-        run: docker image save -o ${{ runner.temp }}/odkfull.tar
+        run: docker image save -o ${{ runner.temp }}/odkfull.tar obolibrary/odkfull:latest
       - name: Upload exported archive
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This PR refactors the main test workflow in two distinct jobs: one to build the images (which only needs to be done on Ubuntu), and one to run the tests (once on every supported system: GNU/Linux, macOS, and Windows).

closes #941