### PR TITLE
Add compatibility wrappers for pre-1.7 repositories.

### DIFF
--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -126,6 +126,10 @@ RUN mkdir /tools && ln -s /usr/local/bin/odk /tools/odk.py && \
 # Install the OBO extended prefix map
 COPY resources/obo.epm.json /odk/resources
 
+# Install wrapper scripts for compatibility with pre-1.7 Makefiles
+COPY --chmod=755 scripts/compat-check-rdfxml.sh /odk/bin/check-rdfxml
+COPY --chmod=755 scripts/compat-context2csv.sh /odk/bin/context2csv
+
 # Install anything that may be missing from ODK-Core
 RUN odk install /odk
 

--- a/docker/odklite/Dockerfile
+++ b/docker/odklite/Dockerfile
@@ -116,22 +116,29 @@ RUN sed -i s/@@ODK_IMAGE_VERSION@@/$ODK_VERSION/ /odk/bin/odk-info
 # Install a helper script to launch a repository update
 COPY --chmod=755 scripts/update_repo.sh /odk/bin/update_repo
 
-# The odk script used to be named `odk.py` and to be located at
-# /tools/odk.py, and both the name (with the `.py` extension) and the
-# full path have been hardcoded at several places, so we need some
-# symlinks for compatibility.
-RUN mkdir /tools && ln -s /usr/local/bin/odk /tools/odk.py && \
-    ln -s /usr/local/bin/odk /odk/bin/odk.py
-
 # Install the OBO extended prefix map
 COPY resources/obo.epm.json /odk/resources
 
-# Install wrapper scripts for compatibility with pre-1.7 Makefiles
-COPY --chmod=755 scripts/compat-check-rdfxml.sh /odk/bin/check-rdfxml
-COPY --chmod=755 scripts/compat-context2csv.sh /odk/bin/context2csv
-
 # Install anything that may be missing from ODK-Core
 RUN odk install /odk
+
+# Compatibility layer for work with pre-1.7 repositories.
+# (1) We need symlinks for several files and directories that have
+#     changed in 1.7 but which have been hardcoded in several places in
+#     pre-1.7 repos:
+#     (a) the `odk` script;
+#     (b) the directory containing the ROBOT plugins;
+#     (c) the directory containing the templates.
+RUN mkdir -p /tools && \
+    ln -s /usr/local/bin/odk /tools/odk.py && \
+    ln -s /usr/local/bin/odk /odk/bin/odk.py && \
+    ln -s /odk/resources/robot/plugins /tools/robot-plugins && \
+    ln -s /usr/local/lib/python3.12/dist-packages/incatools/odk/templates /tools/templates
+
+# (2) We need wrappers for old individual scripts that have been
+#     consolidated into `odk-helper`.
+COPY --chmod=755 scripts/compat-check-rdfxml.sh /odk/bin/check-rdfxml
+COPY --chmod=755 scripts/compat-context2csv.sh /odk/bin/context2csv
 
 # Run the ODK-Core by default
 CMD odk

--- a/scripts/compat-check-rdfxml.sh
+++ b/scripts/compat-check-rdfxml.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec odk-helper check-rdfxml "$@"

--- a/scripts/compat-context2csv.sh
+++ b/scripts/compat-context2csv.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cat > $$.tmp
+exec odk-helper context2csv $$.tmp
+rm $$.tmp

--- a/scripts/compat-context2csv.sh
+++ b/scripts/compat-context2csv.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cat > $$.tmp
-exec odk-helper context2csv $$.tmp
+odk-helper context2csv $$.tmp
 rm $$.tmp

--- a/scripts/compat-context2csv.sh
+++ b/scripts/compat-context2csv.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 cat > $$.tmp
 odk-helper context2csv $$.tmp
+rc=$?
 rm $$.tmp
+exit $rc


### PR DESCRIPTION
ODK versions up to 1.6 had included two small helper scripts:

* check-rdfxml, to check RDF/XML artefacts for correctness;
* context2csv, to convert a JSON-based context file to a CSV file.

In ODK 1.7, as part of the migration to the ODK-Core system, those scripts were consolidated into a single `odk-helper` script. Makefiles generated with ODK 1.7 will automatically call this new `odk-helper` script.

But of course, Makefiles that were generated with a pre-1.7 ODK will still attempt to call the original individual scripts. To make sure that standard workflows from a pre-1.7 ODK instance can still be run with a ODK 1.7 image, we must provide wrapper scripts, which is what we do here.

Similarly, we must also provide symlinks linking the old locations of the ROBOT plugins and of the templates to their new respective locations.

closes #1339