### PR TITLE
[bot] constraints: bump oaklib 0.6.23 -> 0.7.2 (repoint sqlite:obo downloads to the semanticsql CDN)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -177,7 +177,7 @@ nh3==0.3.5
 notebook==7.5.5
 notebook_shim==0.2.4
 numpy==2.4.4
-oaklib==0.6.23
+oaklib==0.7.2
 oauthlib==3.3.1
 ols-client==0.2.1
 ontobio==2.9.12


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Bumps the bundled `oaklib` pin so ODK-based ontology CI downloads `sqlite:obo:` databases from the edge-cached CDN (`https://semanticsql.berkeleybop.io`) instead of the raw S3 bucket.

OAK v0.7.2 changed the default semsql download base to the CDN and switched off the stdlib `urllib` backend (the CDN returns 403 to `Python-urllib`). ODK currently pins `oaklib==0.6.23` (raw S3 + urllib), so the released fix does not reach any downstream ODK ontology CI until this bump + an image rebuild — the single largest-blast-radius repoint available.

**Please verify** 0.6.23 → 0.7.2 compatibility before merge (that is why this is a one-line proposal for review). `semsql==0.4.0` (line 270) may also need a companion bump once a semsql release carrying the CDN default is cut (INCATools/semantic-sql#114).

Refs INCATools/ontology-development-kit#1354, INCATools/ontology-access-kit#880 / #897.

_— Posted by Claude Code agent on behalf of @kltm._
