### PR TITLE
Fix update constraints

### DIFF
--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
       - name: Build constraints.txt
         run: |
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ubuntu:24.04 \
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ubuntu:26.04 \
           sh scripts/update-constraints.sh --in-docker
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/constraints.txt
+++ b/constraints.txt
@@ -51,9 +51,10 @@ deprecation==2.1.0
 diskcache==5.6.3
 distlib==0.4.0
 distro==1.9.0
-docker==6.1.3
+docker==7.2.0
 docutils==0.18.1
 dosdp==0.1.10.dev1
+duckdb==1.5.4
 EditorConfig==0.17.1
 et_xmlfile==2.0.0
 eutils==0.6.1
@@ -134,7 +135,7 @@ jupyterlab_widgets==3.0.16
 keyring==25.7.0
 kgcl-rdflib==0.5.0
 kgcl_schema==0.6.9
-kgx==2.3.2
+kgx==2.7.0
 kiwisolver==1.5.0
 lark==1.3.1
 librt==0.9.0
@@ -222,6 +223,7 @@ pydantic_core==2.46.3
 pydotplus==2.0.2
 PyGithub==2.9.1
 Pygments==2.20.0
+pyjelly==0.8.0
 PyJSG==0.12.3
 PyJWT==2.12.1
 pymdown-extensions==10.21.2
@@ -235,6 +237,7 @@ pyspellchecker==0.9.0
 pystow==0.8.11
 pytest==9.0.3
 pytest-logging==2015.11.4
+python-arango==8.3.3
 python-dateutil==2.9.0.post0
 python-discovery==1.2.2
 python-dotenv==1.2.2

--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -33,13 +33,23 @@ funowl
 jinjanator
 jsonschema2md
 jupyter
-kgx
+# kgx between 2.3.3 and 2.6.0 (included) has been pinning a version of
+# PyArrow that is too old to be available as a pre-compiled wheel,
+# forcing us to compile it (which is a PITA because it requires the
+# non-Python Arrow library to be available on the build system). We need
+# to force either kgx < 2.3.3 (before the introduction of the PyArrow
+# dependency) or kgx >= 2.7.0 (after the pinning has been relaxed); we
+# do the latter.
+kgx >= 2.7.0
 linkml-map
 matplotlib
 matplotlib_venn
 networkx
 numpy
-ontobio
+# We know ontobio-2.9.12 should work fine (this has been the version
+# provided with the ODK for quite some time), but for some reason pip
+# regularly wants to downgrade it to a 2-years old version.
+ontobio >= 2.9.12
 ontodev-cogs
 ontodev-gizmos
 pandas

--- a/scripts/update-constraints.sh
+++ b/scripts/update-constraints.sh
@@ -18,7 +18,13 @@ if [ $in_docker -eq 1 ]; then
 
     # Now additionally install virtualenv, which we will need to
     # install all ODK packages in a separate environment.
-    apt-get install -y --no-install-recommends python3-virtualenv
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python3-virtualenv
+
+    # And also install anything we might need to build a Python
+    # package from source (as we sometimes do in the builder image).
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential cmake clang rustc cargo
 
     # Make sure we are using below the same version of Python as the
     # one in the ODK


### PR DESCRIPTION
This PR fixes a handful of issues with the mechanism to update constraints:

(1) It updates the `constraints.yml` GitHub Action to make sure it uses the same base image as the ODK itself (this should really have been done when the base image was updated).

(2) It updates the `update-constraints.sh` script to make sure that the container in which the constraints are computed has all the tools required to build Python packages from source, in case some of our packages would need to be built from source (whether this is the case or not may vary over time, because it depends on whether all of our dependencies provide pre-compiled wheels arm for Python 3.14 on x86_64 and arm64, something that may change whenever a new version of a dependency is available).

(3) It includes “reverse pins” to force PIP’s dependency solver to use recent versions of `kgx` and `ontobio`. For some reasons, those packages tend to be regularly downgraded, and this can have cascading effect (in particular, as soon as `ontobio` is downgraded to version 2.8.5, this results in a systematic build failure).