### PR TITLE
Enforce make constraints.txt to use linux/amd64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ publish-multiarch-dev:
 
 # This should use the same base image as the one used to build the ODK itself.
 constraints.txt: python-requirements.txt
-	docker run -v $$PWD:/work -w /work --rm -ti ubuntu:26.04 /work/scripts/update-constraints.sh --in-docker
+	docker run --platform linux/amd64 -v $$PWD:/work -w /work --rm -ti ubuntu:26.04 /work/scripts/update-constraints.sh --in-docker
 
 clean-tests:
 	rm -rf target/*


### PR DESCRIPTION
The `make constraints.txt` target runs inside an `x86_64` (`amd64`) container, because that is the architecture of the ODK builder image and therefore the one the constraints must reflect.

On native `arm64` some packages (e.g. `py-horned-owl`, a Rust extension) have no pre-built wheel, and pip would try to compile them from source and fail (`error: linker cc not found`) — besides which the resulting constraints would not match the `amd64` builder image.