### PR TITLE
Bump GitHub Actions.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Create dummy Git user name

--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Set up the QEMU static binaries
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/constraints.yml
+++ b/.github/workflows/constraints.yml
@@ -13,7 +13,7 @@ jobs:
         # This is to fail early in case docker is not available on the base image..
         run: docker --version
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
       - name: Build constraints.txt
@@ -21,7 +21,7 @@ jobs:
           docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace ubuntu:26.04 \
           sh scripts/update-constraints.sh --in-docker
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         if: ${{ success() }}
         with:
           branch: update-constraints

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master

--- a/.github/workflows/update-epm.yml
+++ b/.github/workflows/update-epm.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         
       - name: Work around permission issue
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -18,7 +18,7 @@ jobs:
           wget "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/obo.epm.json" -O resources/obo.epm.json
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         if: ${{ success() }}
         with:
           branch: update-obo-epm


### PR DESCRIPTION
This PR simply updates all GitHub Actions used in this repository.

Note: This is _not_ related to #1346, which is about updating the GitHub Actions used in repositories seeded by the ODK. This PR is solely about our own repository.

Note (2): At some point we will need to revise how we deploy the ODK documentation. We are currently dependent (in `docs.yaml`) on a [GitHub Action](https://github.com/mhausenblas/mkdocs-deploy-gh-pages) that has not had any new release since 2023.